### PR TITLE
Fix global.json path

### DIFF
--- a/src/backend/MyProject.slnx
+++ b/src/backend/MyProject.slnx
@@ -2,7 +2,7 @@
   <Folder Name="/solution items/">
     <File Path="../../docker-compose.local.yml" />
     <File Path="../../.config/dotnet-tools.json" />
-    <File Path="../../../web-api-template/global.json" />
+    <File Path="../../global.json" />
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
     <File Path="MyProject.WebApi/Dockerfile" />


### PR DESCRIPTION
This PR fixes path for `global.json` file. So it can be accessed from `solution items` folder.