### PR TITLE
fix(auth): hash refresh tokens with SHA-256 before database storage

### DIFF
--- a/src/backend/MyProject.Infrastructure/Cryptography/HashHelper.cs
+++ b/src/backend/MyProject.Infrastructure/Cryptography/HashHelper.cs
@@ -1,0 +1,21 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MyProject.Infrastructure.Cryptography;
+
+/// <summary>
+/// Provides common hashing utilities for the application.
+/// </summary>
+internal static class HashHelper
+{
+    /// <summary>
+    /// Computes a SHA-256 hash of the input string and returns it as a lowercase hex string.
+    /// </summary>
+    /// <param name="input">The string to hash.</param>
+    /// <returns>A 64-character lowercase hexadecimal string.</returns>
+    public static string Sha256(string input)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexStringLower(bytes);
+    }
+}


### PR DESCRIPTION
## Summary
- Refresh tokens are now hashed (SHA-256) before being stored in the database
- Raw tokens are still returned to the client in responses/cookies — only the hash is persisted
- Token lookup during refresh now hashes the incoming token before querying

This prevents token theft if the database is compromised (SQL injection, backup leak, etc.).