### PR TITLE
fix(persistence): filter soft-deleted entities in ExistsAsync

### DIFF
--- a/src/backend/MyProject.Infrastructure/Persistence/BaseEntityRepository.cs
+++ b/src/backend/MyProject.Infrastructure/Persistence/BaseEntityRepository.cs
@@ -92,6 +92,8 @@ internal class BaseEntityRepository<TEntity>(MyProjectDbContext dbContext)
         Expression<Func<TEntity, bool>> predicate,
         CancellationToken cancellationToken = default)
     {
-        return await _dbSet.AnyAsync(predicate, cancellationToken);
+        return await _dbSet
+            .Where(e => !e.IsDeleted)
+            .AnyAsync(predicate, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- `ExistsAsync` now filters out soft-deleted entities (`WHERE NOT is_deleted`), consistent with all other `BaseEntityRepository` methods
- Previously, `ExistsAsync` would return `true` for soft-deleted records, which could cause incorrect business logic decisions