### PR TITLE
refactor(auth): remove unused JwtId property from RefreshToken

### DIFF
--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/RefreshTokenConfiguration.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/RefreshTokenConfiguration.cs
@@ -16,9 +16,6 @@ internal class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken
             .IsRequired()
             .HasMaxLength(255);
 
-        builder.Property(x => x.JwtId)
-            .IsRequired();
-
         builder.Property(x => x.CreatedAt)
             .IsRequired();
 

--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Models/RefreshToken.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Models/RefreshToken.cs
@@ -6,8 +6,6 @@ public class RefreshToken
 
     public string Token { get; set; } = string.Empty;
 
-    public string JwtId { get; set; } = string.Empty;
-
     public DateTime CreatedAt { get; set; }
 
     public DateTime ExpiredAt { get; set; }


### PR DESCRIPTION
## Summary
- Removes the `JwtId` property from the `RefreshToken` model and its EF Core configuration
- The field was marked as required but never populated when creating tokens, storing empty strings
- Leftover from a design where refresh tokens were tied to specific JWT IDs