### PR TITLE
fix(auth): enable account lockout after repeated failed login attempts

### DIFF
--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Extensions/ServiceCollectionExtensions.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,10 @@ public static class ServiceCollectionExtensions
                     opt.Password.RequireNonAlphanumeric = false;
                     opt.Password.RequiredLength = 6;
 
+                    opt.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(5);
+                    opt.Lockout.MaxFailedAccessAttempts = 5;
+                    opt.Lockout.AllowedForNewUsers = true;
+
                     opt.Tokens.PasswordResetTokenProvider = TokenOptions.DefaultEmailProvider;
                     opt.Tokens.EmailConfirmationTokenProvider = TokenOptions.DefaultEmailProvider;
 

--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Services/AuthenticationService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Services/AuthenticationService.cs
@@ -35,7 +35,12 @@ internal class AuthenticationService(
             return Result<AuthenticationOutput>.Failure("Invalid username or password.");
         }
 
-        var signInResult = await signInManager.CheckPasswordSignInAsync(user, password, lockoutOnFailure: false);
+        var signInResult = await signInManager.CheckPasswordSignInAsync(user, password, lockoutOnFailure: true);
+        if (signInResult.IsLockedOut)
+        {
+            return Result<AuthenticationOutput>.Failure("Account is temporarily locked due to multiple failed login attempts. Please try again later.");
+        }
+
         if (!signInResult.Succeeded)
         {
             return Result<AuthenticationOutput>.Failure("Invalid username or password.");


### PR DESCRIPTION
## Summary
- Configures ASP.NET Identity lockout policy: 5 failed attempts triggers a 5-minute lockout
- Flips `lockoutOnFailure: false` to `true` in `CheckPasswordSignInAsync` so failed attempts are actually counted
- Adds distinct error message when a locked-out user attempts to login, so they know to wait rather than keep trying