### PR TITLE
fix(persistence): add global soft-delete query filter in BaseEntityConfiguration

### DIFF
--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -165,7 +165,7 @@ Key rules:
 
 ## EF Core Configuration
 
-Configurations inherit from `BaseEntityConfiguration<T>`, which handles all `BaseEntity` fields (primary key, audit columns, soft delete index). Override `ConfigureEntity` to add entity-specific mapping:
+Configurations inherit from `BaseEntityConfiguration<T>`, which handles all `BaseEntity` fields (primary key, audit columns, soft delete index, and a global query filter that excludes soft-deleted entities). Override `ConfigureEntity` to add entity-specific mapping:
 
 ```csharp
 // Infrastructure/Features/Orders/Configurations/OrderConfiguration.cs
@@ -494,7 +494,7 @@ public interface IBaseEntityRepository<TEntity> where TEntity : BaseEntity
 }
 ```
 
-All queries automatically exclude soft-deleted records (`WHERE NOT is_deleted`). Use `IUnitOfWork` for explicit save and transaction control:
+All queries automatically exclude soft-deleted records via a global EF Core query filter (`HasQueryFilter(e => !e.IsDeleted)`) configured in `BaseEntityConfiguration`. Use `.IgnoreQueryFilters()` when you need to query deleted entities (e.g., `RestoreAsync`). Use `IUnitOfWork` for explicit save and transaction control:
 
 ```csharp
 await repository.AddAsync(entity, ct);

--- a/src/backend/MyProject.Infrastructure/Persistence/Configurations/BaseEntityConfiguration.cs
+++ b/src/backend/MyProject.Infrastructure/Persistence/Configurations/BaseEntityConfiguration.cs
@@ -31,6 +31,10 @@ public abstract class BaseEntityConfiguration<TEntity> : IEntityTypeConfiguratio
         // Add index on IsDeleted for better performance with soft delete filtering
         builder.HasIndex(e => e.IsDeleted);
 
+        // Global query filter — automatically excludes soft-deleted entities from all queries.
+        // Use .IgnoreQueryFilters() to explicitly query deleted entities (e.g., RestoreAsync).
+        builder.HasQueryFilter(e => !e.IsDeleted);
+
         // Configure entity-specific properties
         ConfigureEntity(builder);
     }


### PR DESCRIPTION
## Summary

- Add `HasQueryFilter(e => !e.IsDeleted)` to `BaseEntityConfiguration` so EF Core excludes soft-deleted entities at the database level for all queries
- Remove redundant manual `Where(e => !e.IsDeleted)` from all `BaseEntityRepository` methods
- Add `IgnoreQueryFilters()` to `RestoreAsync` so it can find deleted entities
- Update `AGENTS.md` docs to reflect the new query filter behavior

## Why

Any code that queries `DbContext` directly (instead of going through `BaseEntityRepository`) bypasses the manual soft-delete filters, potentially leaking soft-deleted data. A global query filter at the EF Core level ensures the filter is applied consistently regardless of how queries are written.

Closes #35