### PR TITLE
fix(auth): add JWT key minimum length validation and placeholder rejection

### DIFF
--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Options/AuthenticationOptions.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Options/AuthenticationOptions.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
 namespace MyProject.Infrastructure.Features.Authentication.Options;
 
@@ -16,6 +17,7 @@ public sealed class AuthenticationOptions
     /// Contains signing key, issuer, audience, and token lifetime settings.
     /// </summary>
     [Required]
+    [ValidateObjectMembers]
     public JwtOptions Jwt { get; init; } = new();
 
     /// <summary>
@@ -55,6 +57,7 @@ public sealed class AuthenticationOptions
         /// <summary>
         /// Gets or sets the refresh token configuration.
         /// </summary>
+        [ValidateObjectMembers]
         public RefreshTokenOptions RefreshToken { get; init; } = new();
 
         /// <summary>

--- a/src/backend/MyProject.WebApi/Options/RateLimitingOptions.cs
+++ b/src/backend/MyProject.WebApi/Options/RateLimitingOptions.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
 namespace MyProject.WebApi.Options;
 
@@ -16,6 +17,7 @@ public sealed class RateLimitingOptions
     /// Applies a fixed-window limit across all endpoints.
     /// </summary>
     [Required]
+    [ValidateObjectMembers]
     public GlobalLimitOptions Global { get; init; } = new();
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Add `[MinLength(32)]` to `JwtOptions.Key` to enforce HMAC-SHA256 minimum key length at startup
- Implement `IValidatableObject` on `JwtOptions` to reject keys containing placeholder text (`CHANGE_ME`, `placeholder`)
- Replace dev keys in `appsettings.json` and `.env.example` with values that pass validation unconditionally
- Document Options pattern conventions in `AGENTS.md` (data annotations + `IValidatableObject`, never `IValidateOptions`)

## Why

HMAC-SHA256 requires at least 256 bits (32 bytes) for security. Without minimum length enforcement, a short key could be deployed to production. Additionally, placeholder keys like `CHANGE_ME_IN_PRODUCTION__...` in `appsettings.json` could reach production if not overridden, allowing token forgery.

Closes #36