### PR TITLE
fix(api): remove UseDeveloperExceptionPage to prevent stack trace leakage

### DIFF
--- a/src/backend/MyProject.WebApi/Program.cs
+++ b/src/backend/MyProject.WebApi/Program.cs
@@ -104,9 +104,6 @@ try
 
     if (app.Environment.IsDevelopment())
     {
-        Log.Debug("Setting UseDeveloperExceptionPage");
-        app.UseDeveloperExceptionPage();
-
         Log.Debug("Apply migrations to local database");
         app.ApplyMigrations();
 


### PR DESCRIPTION
## Summary

- Remove `UseDeveloperExceptionPage()` from `Program.cs`

## Why

`UseDeveloperExceptionPage()` was registered **before** `ExceptionHandlingMiddleware` in the pipeline, which means it short-circuited the custom error handler entirely. If `Development` environment were accidentally enabled in production, full stack traces and source code would leak to any caller.

The custom `ExceptionHandlingMiddleware` already includes stack traces in development via the `Details` field in `ErrorResponse` — the built-in developer exception page was fully redundant.

Closes #37