### PR TITLE
fix(persistence): use PostgreSQL backslash escaping for SQL LIKE wildcards

### DIFF
--- a/src/backend/MyProject.Infrastructure/Persistence/Extensions/StringExtensions.cs
+++ b/src/backend/MyProject.Infrastructure/Persistence/Extensions/StringExtensions.cs
@@ -8,8 +8,8 @@ public static class StringExtensions
     extension(string input)
     {
         /// <summary>
-        /// Escapes special characters in a string for safe use in SQL LIKE queries.
-        /// Removes control characters and escapes SQL LIKE wildcards.
+        /// Escapes special characters in a string for safe use in PostgreSQL LIKE queries.
+        /// Removes control characters and escapes LIKE wildcards using backslash escaping.
         /// </summary>
         /// <returns>A sanitized and escaped string safe for SQL LIKE operations</returns>
         public string EscapeForSqlLike()
@@ -20,9 +20,9 @@ public static class StringExtensions
                 .Trim();
 
             return sanitized
-                .Replace("[", "[[]")
-                .Replace("%", "[%]")
-                .Replace("_", "[_]");
+                .Replace(@"\", @"\\")
+                .Replace("%", @"\%")
+                .Replace("_", @"\_");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- Replace SQL Server bracket escaping (`[%]`, `[_]`, `[[]`) with PostgreSQL backslash escaping (`\%`, `\_`, `\\`) in `EscapeForSqlLike`

## Why

The existing bracket-based LIKE escaping syntax (`[%]`, `[_]`) is SQL Server-specific and does nothing in PostgreSQL. This means LIKE wildcards in user input are passed through unescaped, allowing wildcard injection — a user could craft search terms containing `%` or `_` to match unintended data.

PostgreSQL uses backslash as the default LIKE escape character (when `standard_conforming_strings = on`, the default since 9.1).

Closes #38