### PR TITLE
fix(frontend): gate internal API URL exposure on dev mode only

### DIFF
--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -473,12 +473,12 @@ export const load: LayoutServerLoad = async ({ parent }) => {
 
 ### Root Layout Data
 
-The root `+layout.server.ts` fetches the user and locale for all routes:
+The root `+layout.server.ts` fetches the user and locale for all routes. In development, it also exposes the internal API URL for debugging (visible in the login page status indicator):
 
 ```typescript
 export const load: LayoutServerLoad = async ({ locals, fetch, url }) => {
 	const user = await getUser(fetch, url.origin);
-	return { user, apiUrl: SERVER_CONFIG.API_URL, locale: locals.locale };
+	return { user, locale: locals.locale, apiUrl: dev ? SERVER_CONFIG.API_URL : undefined };
 };
 ```
 

--- a/src/frontend/src/lib/components/auth/LoginForm.svelte
+++ b/src/frontend/src/lib/components/auth/LoginForm.svelte
@@ -16,7 +16,7 @@
 	import { LoginBackground, RegisterDialog } from '$lib/components/auth';
 	import { toast } from '$lib/components/ui/sonner';
 
-	let { apiUrl } = $props();
+	let { apiUrl }: { apiUrl?: string } = $props();
 
 	let email = $state('');
 	let password = $state('');
@@ -91,7 +91,7 @@
 		title={apiUrl}
 	>
 		<StatusIndicator status={isApiOnline ? 'online' : 'offline'} size="sm" />
-		<span class="hidden group-hover:inline">{apiUrl}</span>
+		<span class="hidden group-hover:inline">{apiUrl ?? 'API'}</span>
 	</div>
 
 	{#if !isSuccess}

--- a/src/frontend/src/routes/+layout.server.ts
+++ b/src/frontend/src/routes/+layout.server.ts
@@ -1,8 +1,9 @@
 import type { LayoutServerLoad } from './$types';
+import { dev } from '$app/environment';
 import { SERVER_CONFIG } from '$lib/config/server';
 import { getUser } from '$lib/auth';
 
 export const load: LayoutServerLoad = async ({ locals, fetch, url }) => {
 	const user = await getUser(fetch, url.origin);
-	return { user, apiUrl: SERVER_CONFIG.API_URL, locale: locals.locale };
+	return { user, locale: locals.locale, apiUrl: dev ? SERVER_CONFIG.API_URL : undefined };
 };


### PR DESCRIPTION
## Summary

- Gate `SERVER_CONFIG.API_URL` exposure on `dev` from `$app/environment` — the internal backend URL (e.g. `http://api:8080`) is only sent to the browser in development mode
- In production/preview, `apiUrl` is `undefined` and the internal address never reaches the client
- `LoginForm` shows the full backend URL on hover in dev (useful for debugging which backend the frontend proxies to), falls back to generic "API" label otherwise
- Update frontend `AGENTS.md` root layout data example to document the conditional

## Why

The internal Docker service URL (`http://api:8080`) was being sent to the browser in all environments and displayed on the login page. This exposes internal network topology (container names, ports) to visitors in production, aiding reconnaissance for attackers.

However, the URL is genuinely useful during local development — it shows which backend the frontend is proxying to (especially relevant when switching between Docker and Rider/VS debugging). Rather than removing it entirely, we gate it on SvelteKit's `dev` flag so it's only available in development.

Closes #39