### PR TITLE
refactor(api): make UsersController extend ApiController base class

### DIFF
--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -402,9 +402,9 @@ public class UserResponse
 ### Authorized Endpoints — Extend `ApiController`
 
 ```csharp
-// Shared/ApiController.cs — base for all authorized, versioned controllers
+// Shared/ApiController.cs — base for all authorized controllers
 [ApiController]
-[Route("api/v1/[controller]")]
+[Route("api/[controller]")]
 [Authorize]
 public abstract class ApiController : ControllerBase;
 ```

--- a/src/backend/MyProject.WebApi/Features/Users/UsersController.cs
+++ b/src/backend/MyProject.WebApi/Features/Users/UsersController.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MyProject.Application.Identity;
 using MyProject.WebApi.Features.Users.Dtos;
@@ -9,10 +8,7 @@ namespace MyProject.WebApi.Features.Users;
 /// <summary>
 /// Controller for managing user profiles and information.
 /// </summary>
-[ApiController]
-[Route("api/[controller]")]
-[Authorize]
-public class UsersController(IUserService userService) : ControllerBase
+public class UsersController(IUserService userService) : ApiController
 {
     /// <summary>
     /// Gets the current authenticated user's information

--- a/src/backend/MyProject.WebApi/Shared/ApiController.cs
+++ b/src/backend/MyProject.WebApi/Shared/ApiController.cs
@@ -4,10 +4,15 @@ using Microsoft.AspNetCore.Mvc;
 namespace MyProject.WebApi.Shared;
 
 /// <summary>
-/// Abstract base controller for all authorized, versioned API endpoints.
-/// Provides <c>[ApiController]</c>, <c>[Authorize]</c>, and the <c>api/v1/[controller]</c> route prefix.
+/// Abstract base controller for all authorized API endpoints.
+/// Provides <c>[ApiController]</c>, <c>[Authorize]</c>, and the <c>api/[controller]</c> route prefix.
+/// <para>
+/// Controllers that require authentication should extend this class to inherit the default
+/// <c>[Authorize]</c> attribute and consistent route prefix. Public controllers (e.g. auth)
+/// should extend <see cref="ControllerBase"/> directly with their own route.
+/// </para>
 /// </summary>
 [ApiController]
-[Route("api/v1/[controller]")]
+[Route("api/[controller]")]
 [Authorize]
 public abstract class ApiController : ControllerBase;


### PR DESCRIPTION
## Summary

- Changes `ApiController` route from `api/v1/[controller]` to `api/[controller]` — API versioning isn't in use, so the `v1` prefix created unnecessary route inconsistency
- Makes `UsersController` extend `ApiController`, inheriting `[Authorize]`, `[ApiController]`, and route prefix
- `AuthController` stays on `ControllerBase` since its endpoints are mostly public
- Updates `AGENTS.md` controller conventions to match

**No route changes** — `UsersController` was already at `api/[controller]`, and now inherits it from the base class instead of declaring it directly.

Closes #78