### PR TITLE
fix(api): use init-only setters on PaginatedResponse properties

### DIFF
--- a/src/backend/MyProject.WebApi/Shared/PaginatedResponse.cs
+++ b/src/backend/MyProject.WebApi/Shared/PaginatedResponse.cs
@@ -8,17 +8,17 @@ public abstract class PaginatedResponse
     /// <summary>
     /// The total number of items (across all pages).
     /// </summary>
-    public int TotalCount { get; set; }
+    public int TotalCount { get; init; }
 
     /// <summary>
     /// The current page number.
     /// </summary>
-    public int PageNumber { get; set; }
+    public int PageNumber { get; init; }
 
     /// <summary>
     /// The number of items per page.
     /// </summary>
-    public int PageSize { get; set; }
+    public int PageSize { get; init; }
 
     /// <summary>
     /// The total number of pages.


### PR DESCRIPTION
## Summary

Changes `TotalCount`, `PageNumber`, and `PageSize` from `set` to `init` on `PaginatedResponse` — response DTOs should be immutable after construction, matching the convention used by all other response DTOs.

Closes #80