### PR TITLE
fix(domain): make Result<T>.Failure error parameter non-nullable

### DIFF
--- a/src/backend/MyProject.Domain/Result.cs
+++ b/src/backend/MyProject.Domain/Result.cs
@@ -1,4 +1,4 @@
-﻿namespace MyProject.Domain;
+namespace MyProject.Domain;
 
 /// <summary>
 /// Represents the result of an operation, indicating success or failure, and optionally containing a value.
@@ -44,7 +44,7 @@ public class Result<T>
     /// </summary>
     /// <param name="error">The error message.</param>
     /// <returns>A failed result containing the error message.</returns>
-    public static Result<T> Failure(string? error)
+    public static Result<T> Failure(string error)
     {
         return new Result<T>(false, error, default);
     }


### PR DESCRIPTION
## Summary

- Change `Result<T>.Failure(string? error)` to `Result<T>.Failure(string error)` — a failure should always have an error message, making the nullable parameter a design bug.
- Remove BOM from file header (minor cleanup).

Closes #81