### PR TITLE
fix(frontend): use finally() for refresh promise cleanup

### DIFF
--- a/src/frontend/src/lib/api/client.ts
+++ b/src/frontend/src/lib/api/client.ts
@@ -19,18 +19,14 @@ export const createApiClient = (customFetch?: typeof fetch, baseUrl: string = ''
 
 			if (!refreshPromise) {
 				const refreshUrl = baseUrl ? `${baseUrl}/api/auth/refresh` : '/api/auth/refresh';
-				refreshPromise = f(refreshUrl, {
-					method: 'POST'
-				}).then((res) => {
+				refreshPromise = f(refreshUrl, { method: 'POST' }).finally(() => {
 					refreshPromise = null;
-					return res;
 				});
 			}
 
 			const refreshResponse = await refreshPromise;
 
-			if (refreshResponse && refreshResponse.ok) {
-				// Retry the original request
+			if (refreshResponse.ok) {
 				return f(input, init);
 			}
 		}


### PR DESCRIPTION
## Summary

- Replace `.then()` with `.finally()` for refresh promise cleanup in the API client, ensuring the shared promise is always cleared regardless of whether the refresh request succeeds or fails
- Remove unnecessary nullish check on `refreshResponse` — it can never be null since `await refreshPromise` always resolves to the fetch `Response`

Closes #57