### PR TITLE
fix(frontend): add data: to CSP img-src for Vite-inlined assets

### DIFF
--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -278,7 +278,7 @@ kit: {
 		directives: {
 			'script-src': ['self', 'nonce'],
 			'style-src': ['self', 'unsafe-inline'],   // Required for Svelte transitions
-			'img-src': ['self', 'https:'],
+			'img-src': ['self', 'https:', 'data:'],    // data: required for Vite-inlined assets
 			'frame-ancestors': ['none']
 		}
 	}
@@ -289,7 +289,7 @@ Key decisions:
 
 - **`script-src`**: Nonce-based. The FOUC prevention script in `app.html` uses `%sveltekit.nonce%`.
 - **`style-src`**: Requires `'unsafe-inline'` because Svelte transitions (`fly`, `scale`) inject inline `<style>` elements at runtime. This is a documented SvelteKit limitation.
-- **`img-src`**: `'self' https:` allows external avatar URLs over HTTPS only.
+- **`img-src`**: `'self' https: data:` allows external avatar URLs over HTTPS and Vite-inlined assets. Vite inlines files under 4KB as `data:` URIs at build time — this affects the favicon SVG and most `flag-icons` CSS sprites (country flags used in the phone input and language selector). Without `data:`, these assets are blocked by CSP.
 - **`frame-ancestors`**: `'none'` — defense-in-depth alongside `X-Frame-Options: DENY`.
 
 CSP is set by the SvelteKit framework (added to responses automatically). The `hooks.server.ts` does NOT set CSP — there is no conflict.

--- a/src/frontend/svelte.config.js
+++ b/src/frontend/svelte.config.js
@@ -14,7 +14,7 @@ const config = {
 				'default-src': ['self'],
 				'script-src': ['self', 'nonce'],
 				'style-src': ['self', 'unsafe-inline'],
-				'img-src': ['self', 'https:'],
+				'img-src': ['self', 'https:', 'data:'],
 				'font-src': ['self'],
 				'connect-src': ['self'],
 				'frame-ancestors': ['none'],


### PR DESCRIPTION
## Summary

- Add `data:` to `img-src` CSP directive in `svelte.config.js` to allow Vite-inlined assets
- Update CSP documentation in frontend `AGENTS.md` to reflect the change and explain why `data:` is needed

## Problem

PR #96 introduced CSP with `img-src: 'self' https:`. Vite inlines files under 4KB as `data:` URIs at build time. This blocks:

1. **Flag icons** — `flag-icons` CSS library uses SVG sprites as `background-image`. Most flags (200 of 271) are under 4KB and get inlined as `data:image/svg+xml` URIs. Flags were invisible in the language selector and phone input.
2. **Favicon** — The `favicon.svg` (1.5KB) is imported via Vite and inlined as a `data:` URI. The `<link rel="icon">` was blocked by CSP.

## Fix

Added `data:` to `img-src`: `'self' https: data:`

The `data:` scheme for `img-src` has minimal security risk — it only controls image loading, not script execution.

## Regression Audit

Audited all 6 PRs merged in the last batch (#96-#101). Findings:

| PR | Status | Notes |
|---|---|---|
| #96 (CSP) | **Fixed here** | `img-src` missing `data:` — broke flags + favicon |
| #97 (.finally()) | **Separate PR needed** | Missing try/catch around `await refreshPromise` — network errors propagate unhandled |
| #98 (code quality) | Clean | No regressions |
| #99 (i18n) | Clean | All keys present in both locales |
| #100 (responsive CSS) | Clean | Sheet merge conflict resolved correctly |
| #101 (AGENTS.md) | Clean | No issues |