### PR TITLE
fix(frontend): handle network errors during token refresh gracefully

### DIFF
--- a/src/frontend/src/lib/api/client.ts
+++ b/src/frontend/src/lib/api/client.ts
@@ -24,7 +24,12 @@ export const createApiClient = (customFetch?: typeof fetch, baseUrl: string = ''
 				});
 			}
 
-			const refreshResponse = await refreshPromise;
+			let refreshResponse: Response;
+			try {
+				refreshResponse = await refreshPromise;
+			} catch {
+				return response;
+			}
 
 			if (refreshResponse.ok) {
 				return f(input, init);


### PR DESCRIPTION
## Summary

- Add try/catch around `await refreshPromise` in `client.ts` to handle network errors during token refresh
- On failure, return the original 401 response instead of propagating an unhandled exception

## Problem

PR #97 refactored the refresh promise cleanup from `.then()` to `.finally()`. The cleanup logic itself is correct, but the code was already missing error handling around the `await refreshPromise` line.

If the refresh fetch throws (network error, DNS failure, `TypeError`, etc.):
1. The `await` propagates the rejection as an unhandled exception
2. The original 401 response is lost — the caller gets an uncaught error instead of a response they can handle
3. If multiple requests are sharing the same `refreshPromise`, all callers get the unhandled exception

## Fix

Wrap `await refreshPromise` in try/catch. On failure, return the original `response` (the 401) so the caller can handle it normally (e.g., redirect to login, show error toast).

```typescript
let refreshResponse: Response;
try {
    refreshResponse = await refreshPromise;
} catch {
    return response; // Return original 401
}
```

## Testing

- Format, lint, and type checks pass (`npm run format && npm run lint && npm run check`)