### PR TITLE
feat(frontend): add ALLOWED_ORIGINS for proxy CSRF check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,8 @@ JWT_SECRET_KEY=super-secret-jwt-key-for-local-development-only-do-not-use-in-pro
 # To debug the backend in Rider/VS while the frontend runs in Docker,
 # uncomment and point to the host machine:
 # API_URL=http://host.docker.internal:5142
+
+# Additional origins allowed through the SvelteKit API proxy CSRF check.
+# Comma-separated. Use when accessing the frontend through a reverse proxy,
+# tunnel (ngrok, Tailscale), or any URL that differs from the app's own origin.
+# ALLOWED_ORIGINS=https://abc123.ngrok-free.app

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -16,6 +16,7 @@ x-db-environment: &db-environment
 
 x-frontend-environment: &frontend-environment
   API_URL: ${API_URL:-http://api:8080}
+  ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-}
 
 x-common-settings: &common-settings
   restart: unless-stopped

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -308,7 +308,22 @@ Never enable HSTS in development — it breaks `localhost` HTTP.
 
 ### CSRF Protection
 
-The API proxy at `routes/api/[...path]/+server.ts` validates the `Origin` header on state-changing requests (POST/PUT/PATCH/DELETE). Cross-origin requests are rejected with 403. This complements SvelteKit's built-in CSRF protection, which only covers form actions — not `+server.ts` routes.
+The API proxy at `routes/api/[...path]/+server.ts` validates the `Origin` header on state-changing requests (POST/PUT/PATCH/DELETE). Requests whose origin doesn't match are rejected with 403. This complements SvelteKit's built-in CSRF protection, which only covers form actions — not `+server.ts` routes.
+
+The check allows:
+
+1. **Same-origin requests** — `Origin` matches `url.origin` (the SvelteKit server's own origin)
+2. **Configured origins** — `Origin` matches an entry in `ALLOWED_ORIGINS` (env var, comma-separated)
+3. **Missing `Origin` header** — safe to allow (same-origin older browsers or non-browser clients)
+
+To allow access through a reverse proxy or tunnel (ngrok, Tailscale), set the `ALLOWED_ORIGINS` environment variable:
+
+```bash
+# In .env
+ALLOWED_ORIGINS=https://abc123.ngrok-free.app
+```
+
+Multiple origins are comma-separated: `ALLOWED_ORIGINS=https://a.example.com,https://b.example.com`
 
 ## Svelte 5 Patterns
 

--- a/src/frontend/src/lib/config/server.ts
+++ b/src/frontend/src/lib/config/server.ts
@@ -1,5 +1,10 @@
 import { env } from '$env/dynamic/private';
 
 export const SERVER_CONFIG = {
-	API_URL: env.API_URL || 'http://localhost:{INIT_API_PORT}'
+	API_URL: env.API_URL || 'http://localhost:{INIT_API_PORT}',
+	/** Additional origins allowed through the API proxy CSRF check (e.g. ngrok, reverse proxy). */
+	ALLOWED_ORIGINS:
+		env.ALLOWED_ORIGINS?.split(',')
+			.map((o) => o.trim())
+			.filter(Boolean) ?? []
 };

--- a/src/frontend/src/routes/api/[...path]/+server.ts
+++ b/src/frontend/src/routes/api/[...path]/+server.ts
@@ -39,7 +39,8 @@ const STRIPPED_RESPONSE_HEADERS = [
 ];
 
 /**
- * Validates that the request Origin header matches the app's own origin.
+ * Validates that the request Origin header matches the app's own origin
+ * or an explicitly configured allowed origin (ALLOWED_ORIGINS env var).
  * This prevents cross-site request forgery for cookie-authenticated requests
  * proxied through SvelteKit (SameSite=None cookies are sent cross-origin).
  *
@@ -61,7 +62,11 @@ function isOriginAllowed(request: Request, url: URL): boolean {
 		return true;
 	}
 
-	return origin === url.origin;
+	if (origin === url.origin) {
+		return true;
+	}
+
+	return SERVER_CONFIG.ALLOWED_ORIGINS.includes(origin);
 }
 
 /** Build a filtered copy of request headers using the allowlist. */

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 	],
 	server: {
 		host: true,
-		port: 5173
+		port: 5173,
+		allowedHosts: true
 	}
 });


### PR DESCRIPTION
## Summary

- Add `ALLOWED_ORIGINS` environment variable to the SvelteKit API proxy's CSRF origin check, allowing access through HTTPS tunnels (ngrok, Tailscale Funnel, Cloudflare Tunnel) and reverse proxies
- Add `allowedHosts: true` to Vite dev server config so it accepts requests from any hostname (not just `localhost`)
- Document the phone/device testing workflow in root `AGENTS.md` (Developer Workflows section)
- Update CSRF Protection docs in `src/frontend/AGENTS.md` with the three allowed origin conditions

## Why

Testing on a phone over LAN (`http://192.168.x.x:13000`) doesn't work because the app uses `Secure` + `SameSite=None` cookies, which browsers silently discard over plain HTTP. The solution is to use an HTTPS tunnel (e.g. ngrok), but that requires two fixes:

1. Vite's dev server blocks unknown hostnames by default
2. The CSRF origin check in the API proxy rejects the tunnel's origin

## Changes

| File | Change |
|---|---|
| `src/frontend/src/lib/config/server.ts` | Parse `ALLOWED_ORIGINS` env var (comma-separated) into `string[]` |
| `src/frontend/src/routes/api/[...path]/+server.ts` | Check `SERVER_CONFIG.ALLOWED_ORIGINS.includes(origin)` as third allowed condition |
| `src/frontend/vite.config.ts` | `allowedHosts: true` (dev-only, no production impact) |
| `docker-compose.local.yml` | Pass `ALLOWED_ORIGINS` env var to frontend container |
| `.env.example` | Document `ALLOWED_ORIGINS` with usage example |
| `AGENTS.md` | New "Testing on a phone or other device" workflow section |
| `src/frontend/AGENTS.md` | Expanded CSRF Protection section with `ALLOWED_ORIGINS` docs |

## Testing

Tested end-to-end: ngrok tunnel → SvelteKit frontend → API proxy → .NET backend. Login, token refresh, and authenticated requests all work correctly through the tunnel on a mobile device.