### PR TITLE
fix(persistence): add index on RefreshToken.UserId

### DIFF
--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/RefreshTokenConfiguration.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/RefreshTokenConfiguration.cs
@@ -41,5 +41,6 @@ internal class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken
             .OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex(x => x.Token);
+        builder.HasIndex(x => x.UserId);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a database index on `RefreshToken.UserId` to avoid full table scans when looking up tokens by user (token refresh, logout, cleanup)
- EF migration not included — handled by init scripts at this stage

Closes #55