### PR TITLE
fix(cors): add production safeguard for AllowAllOrigins + AllowCredentials

### DIFF
--- a/src/backend/MyProject.WebApi/Extensions/CorsExtensions.cs
+++ b/src/backend/MyProject.WebApi/Extensions/CorsExtensions.cs
@@ -11,11 +11,20 @@ internal static class CorsExtensions
 {
     /// <summary>
     /// Registers CORS services and configures the policy from <see cref="CorsOptions"/>.
+    /// Rejects <c>AllowAllOrigins = true</c> in non-development environments at startup
+    /// to prevent credential-leaking CORS misconfiguration in production.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configuration">The application configuration for reading CORS options.</param>
+    /// <param name="environment">The hosting environment, used to enforce production safeguards.</param>
     /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddCors(this IServiceCollection services, IConfiguration configuration)
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <c>AllowAllOrigins</c> is <c>true</c> in a non-development environment.
+    /// </exception>
+    public static IServiceCollection AddCors(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IWebHostEnvironment environment)
     {
         services.AddOptions<CorsOptions>()
             .BindConfiguration(CorsOptions.SectionName)
@@ -25,13 +34,19 @@ internal static class CorsExtensions
         var corsSettings = configuration.GetSection(CorsOptions.SectionName).Get<CorsOptions>()
                            ?? throw new InvalidOperationException("CORS options are not configured properly.");
 
+        if (corsSettings.AllowAllOrigins && !environment.IsDevelopment())
+        {
+            throw new InvalidOperationException(
+                "AllowAllOrigins is enabled in a non-development environment. " +
+                "This allows any origin to make authenticated cross-origin requests and is a security vulnerability. " +
+                "Set Cors:AllowAllOrigins to false and configure Cors:AllowedOrigins with your production domain(s).");
+        }
+
         services.AddCors(options =>
         {
             options.AddPolicy(corsSettings.PolicyName, policy =>
             {
-                {
-                    policy.ConfigureCorsPolicy(corsSettings);
-                }
+                policy.ConfigureCorsPolicy(corsSettings);
             });
         });
 

--- a/src/backend/MyProject.WebApi/Program.cs
+++ b/src/backend/MyProject.WebApi/Program.cs
@@ -64,7 +64,7 @@ try
     }
 
     Log.Debug("Adding Cors Feature");
-    builder.Services.AddCors(builder.Configuration);
+    builder.Services.AddCors(builder.Configuration, builder.Environment);
 
     Log.Debug("Adding Routing => LowercaseUrls");
     builder.Services.AddRouting(options => options.LowercaseUrls = true);


### PR DESCRIPTION
## Summary

- Add startup guard in `CorsExtensions.AddCors()` that throws `InvalidOperationException` when `AllowAllOrigins` is `true` in non-development environments
- Prevents the dangerous combination of `AllowAllOrigins + AllowCredentials` from reaching production, which would allow any origin to make authenticated cross-origin requests
- The guard checks `IWebHostEnvironment.IsDevelopment()` — only Development is exempt (Staging, Production, and custom environments all block it)

Closes #51