### PR TITLE
fix: address review findings across rate limiting, validation, and UX

### DIFF
--- a/FILEMAP.md
+++ b/FILEMAP.md
@@ -52,7 +52,8 @@ Quick-reference for "when you change X, also update Y" and "where does X live?"
 | **`v1.d.ts`** (regenerated) | Type aliases in `$lib/types/index.ts`, any component using changed schemas |
 | **`$lib/types/index.ts`** (add/rename alias) | All imports of the changed type |
 | **`$lib/api/client.ts`** | Every component using `browserClient` or `createApiClient` |
-| **`$lib/api/error-handling.ts`** | Components that call `getErrorMessage`, `mapFieldErrors`, `isValidationProblemDetails` |
+| **`$lib/api/error-handling.ts`** | Components that call `getErrorMessage`, `mapFieldErrors`, `isValidationProblemDetails`, `isRateLimited`, `getRetryAfterSeconds` |
+| **`$lib/state/cooldown.svelte.ts`** | Components that call `createCooldown` for rate limit button disable |
 | **`$lib/config/server.ts`** | Server load functions that import `SERVER_CONFIG` |
 | **`$lib/config/i18n.ts`** | `LanguageSelector`, root layout |
 | **`hooks.server.ts`** | All server responses (security headers, locale) |

--- a/docs/sessions/2026-02-14-admin-api-hardening.md
+++ b/docs/sessions/2026-02-14-admin-api-hardening.md
@@ -116,6 +116,23 @@ Added consistent rate-limit awareness across the entire frontend:
 
 **Approach**: Per-component `isRateLimited` check + toast, not a global interceptor. This avoids coupling the API client to UI concerns, prevents double-toast issues, and works naturally with the existing explicit error handling pattern in each component.
 
+## Review Fixes
+
+Post-review hardening pass addressing suggestions from PR #151 and #152 reviews:
+
+| File | Change | Reason |
+|------|--------|--------|
+| `RoleNameRouteConstraint.cs` | Removed space from regex `[A-Za-z0-9 _-]` → `[A-Za-z0-9_-]` | Role names should not contain spaces — aligns constraint with all validators |
+| `CreateRoleRequestValidator.cs` | Same regex + error message fix | Consistency with route constraint |
+| `UpdateRoleRequestValidator.cs` | Same regex + error message fix | Consistency with route constraint |
+| `RateLimiterExtensions.cs` | One-time warning log when `RemoteIpAddress` is null | Anonymous fallback shares a single bucket — indicates `ForwardedHeaders` misconfiguration |
+| `RateLimitingOptions.cs` | `GlobalLimitOptions` default 100 → 120 | Align constructor default with `appsettings.json` production value |
+| `error-handling.ts` | Added `getRetryAfterSeconds(response)` utility | Extract `Retry-After` header for toast and cooldown |
+| `$lib/state/cooldown.svelte.ts` | New `createCooldown()` rune utility | Reactive countdown timer that disables buttons during rate limit cooldown |
+| `$lib/state/index.ts` | Export `createCooldown` | Barrel re-export |
+| `en.json` / `cs.json` | Added `error_rateLimitedDescriptionWithRetry` parameterized key | Toast shows "Please wait {seconds} seconds and try again" |
+| 11 component files | Import + use `getRetryAfterSeconds`, `createCooldown`; disable buttons during cooldown | Retry-After–aware toast messages and temporary submit disable after 429 |
+
 ## Follow-Up Items
 
 - [ ] Consider adding rate limiting to the `POST /auth/logout` endpoint (low priority since it requires authentication and is idempotent)

--- a/src/backend/MyProject.WebApi/Features/Admin/Dtos/CreateRole/CreateRoleRequestValidator.cs
+++ b/src/backend/MyProject.WebApi/Features/Admin/Dtos/CreateRole/CreateRoleRequestValidator.cs
@@ -15,8 +15,8 @@ public class CreateRoleRequestValidator : AbstractValidator<CreateRoleRequest>
         RuleFor(x => x.Name)
             .NotEmpty()
             .MaximumLength(50)
-            .Matches(@"^[A-Za-z][A-Za-z0-9 _-]*$")
-            .WithMessage("Role name must start with a letter and contain only letters, numbers, spaces, hyphens, or underscores.");
+            .Matches(@"^[A-Za-z][A-Za-z0-9_-]*$")
+            .WithMessage("Role name must start with a letter and contain only letters, numbers, hyphens, or underscores.");
 
         RuleFor(x => x.Description)
             .MaximumLength(200);

--- a/src/backend/MyProject.WebApi/Features/Admin/Dtos/UpdateRole/UpdateRoleRequestValidator.cs
+++ b/src/backend/MyProject.WebApi/Features/Admin/Dtos/UpdateRole/UpdateRoleRequestValidator.cs
@@ -18,8 +18,8 @@ public class UpdateRoleRequestValidator : AbstractValidator<UpdateRoleRequest>
 
         RuleFor(x => x.Name)
             .MaximumLength(50)
-            .Matches(@"^[A-Za-z][A-Za-z0-9 _-]*$")
-            .WithMessage("Role name must start with a letter and contain only letters, numbers, spaces, hyphens, or underscores.")
+            .Matches(@"^[A-Za-z][A-Za-z0-9_-]*$")
+            .WithMessage("Role name must start with a letter and contain only letters, numbers, hyphens, or underscores.")
             .When(x => x.Name is not null);
 
         RuleFor(x => x.Description)

--- a/src/backend/MyProject.WebApi/Options/RateLimitingOptions.cs
+++ b/src/backend/MyProject.WebApi/Options/RateLimitingOptions.cs
@@ -107,11 +107,11 @@ public sealed class RateLimitingOptions
     {
         /// <summary>
         /// Initializes default values for the global rate limiter.
-        /// Defaults to 100 requests per 1 minute with no queuing.
+        /// Defaults to 120 requests per 1 minute with no queuing.
         /// </summary>
         public GlobalLimitOptions()
         {
-            PermitLimit = 100;
+            PermitLimit = 120;
             Window = TimeSpan.FromMinutes(1);
             QueueLimit = 0;
         }

--- a/src/backend/MyProject.WebApi/Routing/RoleNameRouteConstraint.cs
+++ b/src/backend/MyProject.WebApi/Routing/RoleNameRouteConstraint.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 namespace MyProject.WebApi.Routing;
 
 /// <summary>
-/// Route constraint that validates a role name: starts with a letter, followed by letters, digits, spaces, hyphens, or underscores.
+/// Route constraint that validates a role name: starts with a letter, followed by letters, digits, hyphens, or underscores.
 /// Max length 50 characters. Matches the validation in <c>CreateRoleRequestValidator</c> and <c>AssignRoleRequestValidator</c>.
 /// </summary>
 public partial class RoleNameRouteConstraint : IRouteConstraint
@@ -20,6 +20,6 @@ public partial class RoleNameRouteConstraint : IRouteConstraint
         return roleName.Length <= 50 && Pattern().IsMatch(roleName);
     }
 
-    [GeneratedRegex(@"^[A-Za-z][A-Za-z0-9 _-]*$")]
+    [GeneratedRegex(@"^[A-Za-z][A-Za-z0-9_-]*$")]
     private static partial Regex Pattern();
 }

--- a/src/frontend/src/lib/api/error-handling.ts
+++ b/src/frontend/src/lib/api/error-handling.ts
@@ -167,3 +167,19 @@ export function getFetchErrorCode(error: unknown): string | undefined {
 export function isRateLimited(response: Response): boolean {
 	return response.status === 429;
 }
+
+/**
+ * Extracts the integer seconds from the `Retry-After` response header.
+ *
+ * The backend always sends `Retry-After` as an integer (delta-seconds).
+ * Returns `null` when the header is absent or not a valid integer.
+ *
+ * @param response - The HTTP response (typically a 429)
+ * @returns Retry delay in seconds, or null
+ */
+export function getRetryAfterSeconds(response: Response): number | null {
+	const header = response.headers.get('Retry-After');
+	if (!header) return null;
+	const seconds = parseInt(header, 10);
+	return Number.isNaN(seconds) || seconds < 0 ? null : seconds;
+}

--- a/src/frontend/src/lib/state/cooldown.svelte.ts
+++ b/src/frontend/src/lib/state/cooldown.svelte.ts
@@ -1,0 +1,64 @@
+/**
+ * Creates a reactive rate-limit cooldown timer.
+ *
+ * After a 429 response, call `start(seconds)` with the value from
+ * `getRetryAfterSeconds()`. While active, `active` is true and
+ * `remaining` counts down every second — use `active` to disable
+ * submit buttons.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { createCooldown } from '$lib/state';
+ *   const cooldown = createCooldown();
+ *
+ *   function handleSubmit() {
+ *     if (isRateLimited(response)) {
+ *       cooldown.start(getRetryAfterSeconds(response) ?? 60);
+ *       return;
+ *     }
+ *   }
+ * </script>
+ *
+ * <button disabled={cooldown.active}>
+ *   {cooldown.active ? `Wait ${cooldown.remaining}s` : 'Submit'}
+ * </button>
+ * ```
+ */
+export function createCooldown() {
+	let remaining = $state(0);
+	let intervalId: ReturnType<typeof setInterval> | null = null;
+
+	function clear() {
+		if (intervalId) {
+			clearInterval(intervalId);
+			intervalId = null;
+		}
+		remaining = 0;
+	}
+
+	return {
+		/** Whether the cooldown is currently active. */
+		get active() {
+			return remaining > 0;
+		},
+		/** Seconds remaining until the cooldown expires. */
+		get remaining() {
+			return remaining;
+		},
+		/**
+		 * Starts (or restarts) the cooldown for the given number of seconds.
+		 * Automatically clears when the countdown reaches zero.
+		 */
+		start(seconds: number) {
+			clear();
+			remaining = seconds;
+			intervalId = setInterval(() => {
+				remaining--;
+				if (remaining <= 0) {
+					clear();
+				}
+			}, 1000);
+		}
+	};
+}

--- a/src/frontend/src/lib/state/index.ts
+++ b/src/frontend/src/lib/state/index.ts
@@ -1,3 +1,4 @@
+export * from './cooldown.svelte';
 export * from './shake.svelte';
 export * from './shortcuts.svelte';
 export { sidebarState, initSidebar, toggleSidebar, setSidebarCollapsed } from './sidebar.svelte';

--- a/src/frontend/src/messages/cs.json
+++ b/src/frontend/src/messages/cs.json
@@ -179,6 +179,7 @@
 	"error_429_description": "Odesíláte příliš mnoho požadavků. Počkejte chvíli a zkuste to znovu.",
 	"error_rateLimited": "Příliš mnoho požadavků",
 	"error_rateLimitedDescription": "Počkejte chvíli a zkuste to znovu.",
+	"error_rateLimitedDescriptionWithRetry": "Počkejte {seconds} sekund a zkuste to znovu.",
 
 	"error_403_title": "Tudy neprojdeš!",
 	"error_403_description": "Nemáte oprávnění k prohlížení této stránky. Ale snaha se cení.",

--- a/src/frontend/src/messages/en.json
+++ b/src/frontend/src/messages/en.json
@@ -179,6 +179,7 @@
 	"error_429_description": "You're making too many requests. Please wait a moment and try again.",
 	"error_rateLimited": "Too many requests",
 	"error_rateLimitedDescription": "Please wait a moment and try again.",
+	"error_rateLimitedDescriptionWithRetry": "Please wait {seconds} seconds and try again.",
 
 	"error_403_title": "You Shall Not Pass!",
 	"error_403_description": "You don't have permission to be here. Nice try though, we appreciate the effort.",


### PR DESCRIPTION
## Summary

Addresses all review suggestions from PR #151 and #152:

- **Role name validation**: Remove spaces from regex in route constraint + both validators — role names now consistently disallow spaces across the entire stack
- **Anonymous rate limit fallback**: One-time warning log when `RemoteIpAddress` is null, indicating `ForwardedHeaders` middleware misconfiguration behind a reverse proxy
- **GlobalLimitOptions default alignment**: Constructor default 100 → 120 to match `appsettings.json` production value
- **Retry-After–aware toast**: New `getRetryAfterSeconds()` utility extracts the `Retry-After` header; toast shows "Please wait {seconds} seconds" with the actual backend-provided value
- **Rate limit cooldown**: New `createCooldown()` Svelte 5 rune utility temporarily disables submit buttons after a 429, auto-re-enabling when the cooldown expires
- **11 component updates**: All components with API calls now use retry-after in toasts and disable buttons during cooldown
- **Docs**: Updated AGENTS.md (429 handling pattern), FILEMAP.md (impact rows), session notes

## Test plan

- [ ] `dotnet build src/backend/MyProject.slnx` — passes
- [ ] `cd src/frontend && npm run format && npm run lint && npm run check` — passes (0 errors)
- [ ] Trigger a 429 on login → toast shows retry seconds, submit button disabled for the cooldown duration
- [ ] Trigger a 429 on change-password (sensitive, 5 min window) → cooldown is longer than auth endpoints
- [ ] Verify role creation rejects names with spaces (e.g., "My Role" → validation error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)