### PR TITLE
fix(docker): resolve MSB3552 resx error after init migration

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "10.0.3",
+      "version": "10.0.1",
       "commands": [
         "dotnet-ef"
       ],

--- a/src/backend/MyProject.WebApi/Dockerfile
+++ b/src/backend/MyProject.WebApi/Dockerfile
@@ -28,7 +28,7 @@ COPY . .
 
 # Build the application
 WORKDIR "/src/MyProject.WebApi"
-RUN dotnet build "MyProject.WebApi.csproj" -c Release -o /app/build
+RUN dotnet build "MyProject.WebApi.csproj" -c Release
 
 # Publish stage
 FROM build AS publish


### PR DESCRIPTION
## Summary

- Downgrade `dotnet-ef` from 10.0.3 to 10.0.1 to avoid the path separator bug ([dotnet/efcore#37506](https://github.com/dotnet/efcore/issues/37506)) that creates `bin\Debug` directories with literal backslashes on macOS/Linux
- Remove `-o /app/build` from Dockerfile build step (redundant since publish rebuilds, and makes the build fragile to glob expansion issues)

## Root cause

`dotnet-ef` 10.0.2+ generates Windows-style backslash paths (`bin\Debug`) on Unix systems. These directories bypass `.dockerignore`'s `**/bin` pattern (which matches path separators, not literal backslashes), get copied into the Docker context, and corrupt MSBuild's `**/*.resx` glob expansion — causing `MSB3552: Resource file "**/*.resx" cannot be found`.

## Test plan

- [x] `init.sh --name Test --port 13000` with migration succeeds
- [x] `docker build` succeeds after init with migration
- [x] No `bin\Debug` directories created (verified with `find -name '*\\*'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)