### PR TITLE
chore(api): review follow-up — conventions and cleanup

### DIFF
--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -70,7 +70,7 @@ src/backend/
     │   ├── PermissionPolicyProvider.cs
     │   ├── PermissionAuthorizationHandler.cs
     │   └── PermissionRequirement.cs
-    ├── Shared/                    # ApiController, PaginatedRequest/Response, ValidationConstants
+    ├── Shared/                    # ApiController, ProblemFactory, PaginatedRequest/Response, ValidationConstants
     ├── Middlewares/                # ExceptionHandlingMiddleware
     ├── Extensions/                # CORS, rate limiting, health checks
     └── Options/                   # CorsOptions, RateLimitingOptions

--- a/src/backend/MyProject.Infrastructure/MyProject.Infrastructure.csproj
+++ b/src/backend/MyProject.Infrastructure/MyProject.Infrastructure.csproj
@@ -3,7 +3,6 @@
     <ItemGroup>
         <ProjectReference Include="../MyProject.Application/MyProject.Application.csproj"/>
         <ProjectReference Include="../MyProject.Domain/MyProject.Domain.csproj"/>
-        <ProjectReference Include="../MyProject.Shared/MyProject.Shared.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/backend/MyProject.Shared/ErrorType.cs
+++ b/src/backend/MyProject.Shared/ErrorType.cs
@@ -6,11 +6,11 @@ namespace MyProject.Shared;
 public enum ErrorType
 {
     /// <summary>Validation or business rule violation (400 Bad Request).</summary>
-    Validation,
+    Validation = 0,
 
     /// <summary>Authentication or token failure (401 Unauthorized).</summary>
-    Unauthorized,
+    Unauthorized = 1,
 
     /// <summary>Requested resource not found (404 Not Found).</summary>
-    NotFound
+    NotFound = 2
 }

--- a/src/backend/MyProject.Shared/Result.cs
+++ b/src/backend/MyProject.Shared/Result.cs
@@ -48,13 +48,13 @@ public class Result
 
     /// <summary>
     /// Creates a failed result with the specified error message.
-    /// Defaults to <see cref="Shared.ErrorType.Validation"/> (400) at the controller layer.
+    /// Defaults to 400 (Validation) at the controller layer.
     /// </summary>
     /// <param name="error">The error message.</param>
     /// <returns>A failed result containing the error message.</returns>
     public static Result Failure(string error)
     {
-        return new Result(false, error);
+        return new Result(false, error, Shared.ErrorType.Validation);
     }
 
     /// <summary>
@@ -82,6 +82,8 @@ public class Result<T> : Result
     /// Gets the value returned by the operation.
     /// Throws <see cref="InvalidOperationException"/> if the result is a failure.
     /// </summary>
+    // _value! is sound here: Success() guarantees _value is non-null, and the
+    // IsSuccess guard prevents access on failure paths. Same pattern as Nullable<T>.Value.
     public T Value => IsSuccess
         ? _value!
         : throw new InvalidOperationException("Cannot access Value on a failed result.");
@@ -104,13 +106,13 @@ public class Result<T> : Result
 
     /// <summary>
     /// Creates a failed result with the specified error message.
-    /// Defaults to <see cref="Shared.ErrorType.Validation"/> (400) at the controller layer.
+    /// Defaults to 400 (Validation) at the controller layer.
     /// </summary>
     /// <param name="error">The error message.</param>
     /// <returns>A failed result containing the error message.</returns>
     public new static Result<T> Failure(string error)
     {
-        return new Result<T>(false, error, default);
+        return new Result<T>(false, error, default, Shared.ErrorType.Validation);
     }
 
     /// <summary>

--- a/src/backend/MyProject.WebApi/Shared/ProblemFactory.cs
+++ b/src/backend/MyProject.WebApi/Shared/ProblemFactory.cs
@@ -9,7 +9,7 @@ namespace MyProject.WebApi.Shared;
 /// Produces a consistent <see cref="ProblemDetails"/> body with Title set from the
 /// status code's reason phrase.
 /// </summary>
-public static class ProblemFactory
+internal static class ProblemFactory
 {
     /// <summary>
     /// Returns a <see cref="ProblemDetails"/> response with the specified detail and error type.
@@ -33,6 +33,7 @@ public static class ProblemFactory
 
     private static int ToStatusCode(ErrorType? errorType) => errorType switch
     {
+        ErrorType.Validation => StatusCodes.Status400BadRequest,
         ErrorType.Unauthorized => StatusCodes.Status401Unauthorized,
         ErrorType.NotFound => StatusCodes.Status404NotFound,
         _ => StatusCodes.Status400BadRequest


### PR DESCRIPTION
## Summary

Follow-up to #170 addressing review warnings and nits:

- **ErrorType enum**: add explicit integer values (`= 0`, `= 1`, `= 2`) per project enum convention
- **ProblemFactory**: `public` → `internal` (only used within WebApi assembly)
- **Dead `ErrorType.Validation`**: single-arg `Failure()` now explicitly passes `ErrorType.Validation` instead of leaving `ErrorType?` as null; `ToStatusCode` gets an explicit `Validation` branch
- **`_value!` comment**: documents why the null-forgiving operator is sound (IsSuccess guard, same as `Nullable<T>.Value`)
- **XML docs**: replace shadowed `Shared.ErrorType.Validation` cref with plain text
- **Infrastructure csproj**: remove redundant `MyProject.Shared` reference (already transitive via Application)

## Test plan

- [x] `dotnet build src/backend/MyProject.slnx` — 0 warnings, 0 errors
- [ ] Verify error responses still return correct status codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)