### PR TITLE
security(api): add CSRF Origin validation middleware

### DIFF
--- a/src/backend/MyProject.Shared/ErrorMessages.cs
+++ b/src/backend/MyProject.Shared/ErrorMessages.cs
@@ -99,6 +99,14 @@ public static class ErrorMessages
     }
 
     /// <summary>
+    /// Security infrastructure error messages (CSRF, origin validation).
+    /// </summary>
+    public static class Security
+    {
+        public const string CrossOriginRequestBlocked = "Cross-origin requests are not allowed.";
+    }
+
+    /// <summary>
     /// Generic entity operation error messages (repository layer).
     /// </summary>
     public static class Entity

--- a/src/backend/MyProject.WebApi/Middlewares/OriginValidationMiddleware.cs
+++ b/src/backend/MyProject.WebApi/Middlewares/OriginValidationMiddleware.cs
@@ -1,0 +1,84 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using MyProject.Shared;
+using CorsOptions = MyProject.WebApi.Options.CorsOptions;
+
+namespace MyProject.WebApi.Middlewares;
+
+/// <summary>
+/// Validates the <c>Origin</c> header on state-changing requests (POST, PUT, PATCH, DELETE)
+/// to prevent cross-site request forgery when cookies use <c>SameSite=None</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a defense-in-depth measure. The SvelteKit frontend proxy performs the same check,
+/// but this middleware protects the API if the proxy is bypassed (direct API calls with cookies).
+/// </para>
+/// <para>
+/// Requests without an <c>Origin</c> header are allowed through because a missing header on an
+/// unsafe method means either a same-origin request from an older browser or a non-browser client —
+/// neither of which is vulnerable to CSRF.
+/// </para>
+/// <para>Pattern documented in src/backend/AGENTS.md — update both when changing.</para>
+/// </remarks>
+public class OriginValidationMiddleware(
+    RequestDelegate next,
+    IOptions<CorsOptions> corsOptions,
+    ILogger<OriginValidationMiddleware> logger,
+    IProblemDetailsService problemDetailsService)
+{
+    private static readonly HashSet<string> UnsafeMethods =
+        new(["POST", "PUT", "PATCH", "DELETE"], StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Validates the Origin header and either passes the request through or returns 403.
+    /// </summary>
+    public async Task Invoke(HttpContext context)
+    {
+        if (!UnsafeMethods.Contains(context.Request.Method))
+        {
+            await next(context);
+            return;
+        }
+
+        var origin = context.Request.Headers.Origin.ToString();
+
+        if (string.IsNullOrEmpty(origin))
+        {
+            await next(context);
+            return;
+        }
+
+        var options = corsOptions.Value;
+
+        if (options.AllowAllOrigins)
+        {
+            await next(context);
+            return;
+        }
+
+        if (options.AllowedOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase))
+        {
+            await next(context);
+            return;
+        }
+
+        logger.LogWarning(
+            "Blocked cross-origin {Method} request from {Origin} to {Path}",
+            context.Request.Method,
+            origin,
+            context.Request.Path);
+
+        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+
+        await problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = context,
+            ProblemDetails = new ProblemDetails
+            {
+                Status = StatusCodes.Status403Forbidden,
+                Detail = ErrorMessages.Security.CrossOriginRequestBlocked
+            }
+        });
+    }
+}

--- a/src/backend/MyProject.WebApi/Program.cs
+++ b/src/backend/MyProject.WebApi/Program.cs
@@ -147,6 +147,9 @@ try
     Log.Debug("Setting UseCors");
     CorsExtensions.UseCors(app);
 
+    Log.Debug("Setting UseMiddleware => OriginValidationMiddleware");
+    app.UseMiddleware<OriginValidationMiddleware>();
+
     Log.Debug("Setting UseSerilogRequestLogging");
     app.UseSerilogRequestLogging();
 

--- a/src/backend/tests/MyProject.Api.Tests/Middlewares/OriginValidationMiddlewareTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Middlewares/OriginValidationMiddlewareTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using MyProject.Api.Tests.Fixtures;
+using MyProject.Shared;
+
+namespace MyProject.Api.Tests.Middlewares;
+
+/// <summary>
+/// Integration tests for <see cref="WebApi.Middlewares.OriginValidationMiddleware"/>.
+/// <para>
+/// The Testing environment configures <c>AllowedOrigins: ["https://test.example.com"]</c>
+/// with <c>AllowAllOrigins: false</c>, so only that origin passes validation.
+/// </para>
+/// </summary>
+public class OriginValidationMiddlewareTests : IClassFixture<CustomWebApplicationFactory>, IDisposable
+{
+    private const string AllowedOrigin = "https://test.example.com";
+    private const string DisallowedOrigin = "https://evil.example.com";
+
+    /// <summary>
+    /// A public POST endpoint that does not require authentication.
+    /// The middleware runs before any controller logic, so the endpoint
+    /// itself does not matter for rejection tests.
+    /// </summary>
+    private const string PublicPostEndpoint = "/api/v1/auth/login";
+
+    private readonly CustomWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public OriginValidationMiddlewareTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _factory.ResetMocks();
+        _client = factory.CreateClient();
+    }
+
+    public void Dispose() => _client.Dispose();
+
+    // ── Safe methods ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetRequest_WithDisallowedOrigin_PassesThrough()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/users/me");
+        request.Headers.Add("Origin", DisallowedOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        // GET should never be blocked by CSRF middleware — any non-403 proves it passed through
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task HeadRequest_WithDisallowedOrigin_PassesThrough()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Head, "/api/v1/users/me");
+        request.Headers.Add("Origin", DisallowedOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task OptionsRequest_WithDisallowedOrigin_PassesThrough()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Options, PublicPostEndpoint);
+        request.Headers.Add("Origin", DisallowedOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ── Missing Origin ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostRequest_WithoutOriginHeader_PassesThrough()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, PublicPostEndpoint);
+
+        var response = await _client.SendAsync(request);
+
+        // No Origin header means same-origin or non-browser — never blocked
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ── Allowed Origin ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostRequest_WithAllowedOrigin_PassesThrough()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, PublicPostEndpoint);
+        request.Headers.Add("Origin", AllowedOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ── Disallowed Origin — blocked ─────────────────────────────────
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("PATCH")]
+    [InlineData("DELETE")]
+    public async Task UnsafeMethod_WithDisallowedOrigin_Returns403(string method)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), PublicPostEndpoint);
+        request.Headers.Add("Origin", DisallowedOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostRequest_WithDisallowedOrigin_ReturnsProblemDetails()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, PublicPostEndpoint);
+        request.Headers.Add("Origin", DisallowedOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(403, json.GetProperty("status").GetInt32());
+        Assert.Equal(ErrorMessages.Security.CrossOriginRequestBlocked, json.GetProperty("detail").GetString());
+    }
+
+    // ── Origin case insensitivity ───────────────────────────────────
+
+    [Fact]
+    public async Task PostRequest_WithAllowedOriginDifferentCase_PassesThrough()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, PublicPostEndpoint);
+        request.Headers.Add("Origin", AllowedOrigin.ToUpperInvariant());
+
+        var response = await _client.SendAsync(request);
+
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // ── Origin variations ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://test.example.com.evil.com")]
+    [InlineData("https://evil.com")]
+    [InlineData("null")]
+    public async Task PostRequest_WithVariousDisallowedOrigins_Returns403(string origin)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, PublicPostEndpoint);
+        request.Headers.Add("Origin", origin);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+}

--- a/src/backend/tests/MyProject.Unit.Tests/Shared/ErrorMessagesTests.cs
+++ b/src/backend/tests/MyProject.Unit.Tests/Shared/ErrorMessagesTests.cs
@@ -6,7 +6,7 @@ namespace MyProject.Unit.Tests.Shared;
 public class ErrorMessagesTests
 {
     private static readonly string[] ExpectedNestedClasses =
-        ["Auth", "User", "Admin", "Roles", "Pagination", "Server", "Jobs", "Entity"];
+        ["Auth", "User", "Admin", "Roles", "Pagination", "Server", "Jobs", "Security", "Entity"];
 
     [Fact]
     public void AllNestedClasses_ShouldExist()


### PR DESCRIPTION
## Summary
- Adds `OriginValidationMiddleware` that validates the `Origin` header on state-changing requests (POST/PUT/PATCH/DELETE) against the configured CORS allowed origins
- Defense-in-depth: the SvelteKit proxy already does this check, but the backend was unprotected if called directly with `SameSite=None` cookies
- Returns 403 ProblemDetails for disallowed origins; allows missing Origin (same-origin/non-browser) and respects `AllowAllOrigins` in dev
- Adds `ErrorMessages.Security` category and 14 integration tests covering safe methods, missing origin, allowed/disallowed origins, case insensitivity, and origin substring attacks

## Test plan
- [x] All 14 new `OriginValidationMiddlewareTests` pass
- [x] All 346 existing tests continue to pass (no regressions)
- [x] `ErrorMessagesTests.AllNestedClasses_ShouldExist` updated to include `Security`
- [x] Manual verification: existing frontend auth flow works unchanged

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)