### PR TITLE
chore: untrack inlang-managed .gitignore

### DIFF
--- a/src/frontend/project.inlang/.gitignore
+++ b/src/frontend/project.inlang/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!settings.json


### PR DESCRIPTION
## Summary

- Stop tracking `src/frontend/project.inlang/.gitignore` — inlang >=2.5 regenerates this file on every run, causing perpetual dirty git status

## Test plan

- [x] `git status` is clean after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)