### PR TITLE
chore: ignore inlang generated files

### DIFF
--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -22,6 +22,11 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# Inlang (auto-generated — only settings.json is tracked)
+project.inlang/.meta.json
+project.inlang/README.md
+project.inlang/cache/
+
 # Editor directories and files
 .vscode
 .idea


### PR DESCRIPTION
## Summary

- Add `project.inlang/.meta.json`, `README.md`, and `cache/` to frontend `.gitignore`
- These are inlang-generated files that were previously covered by a `.gitignore` inside `project.inlang/` which was removed in #185

Only `project.inlang/settings.json` remains tracked (required by paraglide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)