### PR TITLE
fix(frontend): suppress raw 5xx error details from user-facing UI

### DIFF
--- a/src/frontend/src/lib/api/error-handling.ts
+++ b/src/frontend/src/lib/api/error-handling.ts
@@ -160,6 +160,15 @@ export function getFetchErrorCode(error: unknown): string | undefined {
 }
 
 /**
+ * Returns true when the response indicates a server-side error (5xx).
+ * Use this to suppress raw backend error details that may contain
+ * internal information (e.g. third-party API keys, stack traces).
+ */
+export function isServerError(response: Response): boolean {
+	return response.status >= 500;
+}
+
+/**
  * Returns true when the response is a 429 Too Many Requests.
  */
 export function isRateLimited(response: Response): boolean {

--- a/src/frontend/src/lib/api/mutation.ts
+++ b/src/frontend/src/lib/api/mutation.ts
@@ -11,6 +11,7 @@ import { toast } from '$lib/components/ui/sonner';
 import * as m from '$lib/paraglide/messages';
 import {
 	isRateLimited,
+	isServerError,
 	getRetryAfterSeconds,
 	isValidationProblemDetails,
 	mapFieldErrors,
@@ -86,6 +87,13 @@ export function handleMutationError(
 				: m.error_rateLimitedDescription()
 		});
 		onRateLimited?.();
+		return;
+	}
+
+	if (isServerError(response)) {
+		toast.error(m.error_serverError(), {
+			description: m.error_serverErrorDescription()
+		});
 		return;
 	}
 

--- a/src/frontend/src/messages/cs.json
+++ b/src/frontend/src/messages/cs.json
@@ -197,6 +197,8 @@
 	"error_500_description": "Něco se pokazilo na naší straně. Zkuste to prosím později.",
 	"error_default_title": "Počítač říká ne",
 	"error_default_description": "Něco se pokazilo. Nejsme si jistí co, ale pravděpodobně to není dobré.",
+	"error_serverError": "Něco se pokazilo",
+	"error_serverErrorDescription": "Chyba je na naší straně. Zkuste to prosím za chvíli znovu.",
 	"error_goHome": "Zpět na úvod",
 
 	"settings_deleteAccount_dangerDescription": "Jakmile smažete svůj účet, není cesty zpět. Všechna vaše data budou trvale odstraněna.",

--- a/src/frontend/src/messages/en.json
+++ b/src/frontend/src/messages/en.json
@@ -197,6 +197,8 @@
 	"error_500_description": "The server is having a bad day. Our code monkeys are working hard to fix it.",
 	"error_default_title": "Computer Says No",
 	"error_default_description": "Something went wrong. We're not sure what, but it's probably not good.",
+	"error_serverError": "Something went wrong",
+	"error_serverErrorDescription": "This one's on us, not you. Please try again in a moment.",
 	"error_goHome": "Go back home",
 
 	"settings_deleteAccount_dangerDescription": "Once you delete your account, there is no going back. All your data will be permanently removed.",

--- a/src/frontend/src/routes/+error.svelte
+++ b/src/frontend/src/routes/+error.svelte
@@ -74,7 +74,9 @@
 			</Card.Header>
 			<Card.Content>
 				<p class="text-muted-foreground">
-					{message && message !== 'An unexpected error occurred.' ? message : content.description()}
+					{status < 500 && message && message !== 'An unexpected error occurred.'
+						? message
+						: content.description()}
 				</p>
 			</Card.Content>
 			<Card.Footer class="flex justify-center pb-8">


### PR DESCRIPTION
## Summary

- **`handleMutationError`** now intercepts 5xx responses before they reach `onError` callbacks, showing a generic i18n toast ("Something went wrong / This one's on us") instead of leaking raw backend `detail` (which may contain internal info like third-party API keys or stack traces)
- **`+error.svelte`** now always uses the friendly i18n description for 5xx page errors, never the raw `message`
- Added `isServerError()` utility to `error-handling.ts`

## Test plan

- [ ] Trigger a 500 from a form submission (e.g. misconfigured email provider) — should see generic "Something went wrong" toast, NOT the raw backend detail
- [ ] Trigger a 500 during page load — should see "Server Meltdown" with the friendly description, not a raw error
- [ ] 4xx errors (400, 401, 403, 422) still show specific backend messages as before
- [ ] Rate limiting (429) still shows retry countdown as before

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)