### PR TITLE
fix(deps): revert dotnet-ef to 10.0.1 due to blocking bug

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "10.0.3",
+      "version": "10.0.1",
       "commands": [
         "dotnet-ef"
       ],


### PR DESCRIPTION
## Summary

- Reverts dotnet-ef from 10.0.3 back to 10.0.1 in `.config/dotnet-tools.json`
- 10.0.3 was merged via Dependabot PR #209 but has a known blocking bug for our project

## Test plan

- [x] `dotnet build` passes