### PR TITLE
fix(i18n): replace generic login title with project name

### DIFF
--- a/src/frontend/src/lib/components/auth/LoginForm.svelte
+++ b/src/frontend/src/lib/components/auth/LoginForm.svelte
@@ -113,7 +113,9 @@
 				)}
 			>
 				<Card.Header>
-					<Card.Title class="text-center text-2xl">{m.auth_login_title()}</Card.Title>
+					<Card.Title class="text-center text-2xl"
+						>{m.auth_login_title({ name: m.app_name() })}</Card.Title
+					>
 					<Card.Description class="text-center">{m.auth_login_subtitle()}</Card.Description>
 				</Card.Header>
 				<Card.Content>

--- a/src/frontend/src/messages/cs.json
+++ b/src/frontend/src/messages/cs.json
@@ -66,8 +66,8 @@
 	"country_ro": "Rumunsko",
 	"country_ua": "Ukrajina",
 
-	"auth_login_title": "Vítejte zpět",
-	"auth_login_subtitle": "Přihlaste se ke svému účtu",
+	"auth_login_title": "Vítejte v {name}",
+	"auth_login_subtitle": "Pro pokračování se přihlaste",
 	"auth_login_email": "E-mail",
 	"auth_login_password": "Heslo",
 	"auth_login_submit": "Přihlásit se",

--- a/src/frontend/src/messages/en.json
+++ b/src/frontend/src/messages/en.json
@@ -66,8 +66,8 @@
 	"country_ro": "Romania",
 	"country_ua": "Ukraine",
 
-	"auth_login_title": "Welcome back",
-	"auth_login_subtitle": "Sign in to your account",
+	"auth_login_title": "Welcome to {name}",
+	"auth_login_subtitle": "Sign in to continue",
 	"auth_login_email": "Email address",
 	"auth_login_password": "Password",
 	"auth_login_submit": "Sign in",


### PR DESCRIPTION
## Summary

- Replaced generic "Welcome back" login title with "Welcome to {name}" using the existing `app_name` message key
- Updated subtitle from "Sign in to your account" to "Sign in to continue" for a cleaner pairing
- Updated both EN and CS translations
- After init rename, the login page automatically reflects the project name (e.g. "Welcome to Netrock")

## Test plan

- [x] Login page shows "Welcome to MyProject" (pre-init) 
- [x] Czech locale shows "Vítejte v MyProject"
- [x] Subtitle reads "Sign in to continue" / "Pro pokračování se přihlaste"

🤖 Generated with [Claude Code](https://claude.com/claude-code)