### PR TITLE
fix(auth): localize lockout error message

### DIFF
--- a/src/backend/MyProject.Shared/ErrorMessages.cs
+++ b/src/backend/MyProject.Shared/ErrorMessages.cs
@@ -17,7 +17,7 @@ public static class ErrorMessages
     public static class Auth
     {
         public const string LoginInvalidCredentials = "Invalid username or password.";
-        public const string LoginAccountLocked = "Account is temporarily locked due to multiple failed login attempts. Please try again later.";
+        public const string LoginAccountLocked = "Account is temporarily locked. Please try again later or contact an administrator.";
         public const string RegisterRoleAssignFailed = "Account was created but role assignment failed. Please contact an administrator.";
         public const string TokenMissing = "Refresh token is missing.";
         public const string TokenNotFound = "Refresh token not found.";

--- a/src/frontend/src/lib/components/auth/LoginForm.svelte
+++ b/src/frontend/src/lib/components/auth/LoginForm.svelte
@@ -67,9 +67,13 @@
 					fallback: m.auth_login_error(),
 					onRateLimited: () => shake.trigger(),
 					onError() {
+						const detail = getErrorMessage(apiError, '');
+						const isLocked = detail.includes('temporarily locked');
 						const errorMessage =
 							response.status === 401
-								? getErrorMessage(apiError, m.auth_login_invalidCredentials())
+								? isLocked
+									? m.auth_login_accountLocked()
+									: getErrorMessage(apiError, m.auth_login_invalidCredentials())
 								: getErrorMessage(apiError, m.auth_login_error());
 						toast.error(m.auth_login_failed(), { description: errorMessage });
 						shake.trigger();

--- a/src/frontend/src/messages/cs.json
+++ b/src/frontend/src/messages/cs.json
@@ -74,6 +74,7 @@
 	"auth_login_failed": "Přihlášení se nezdařilo",
 	"auth_login_error": "Došlo k chybě",
 	"auth_login_invalidCredentials": "Nesprávný e-mail nebo heslo",
+	"auth_login_accountLocked": "Účet je dočasně uzamčen. Zkuste to prosím později nebo kontaktujte administrátora.",
 	"auth_login_apiOffline": "API je offline",
 	"auth_login_success": "Přihlášení úspěšné!",
 	"auth_login_rememberMe": "Zapamatovat si mě",

--- a/src/frontend/src/messages/en.json
+++ b/src/frontend/src/messages/en.json
@@ -74,6 +74,7 @@
 	"auth_login_failed": "Login failed",
 	"auth_login_error": "An error occurred",
 	"auth_login_invalidCredentials": "Invalid email or password",
+	"auth_login_accountLocked": "Account is temporarily locked. Please try again later or contact an administrator.",
 	"auth_login_apiOffline": "API is offline",
 	"auth_login_success": "Login successful!",
 	"auth_login_rememberMe": "Remember me",


### PR DESCRIPTION
## Summary
- Make the lockout error message cause-agnostic (no longer mentions "multiple failed login attempts" — accounts can also be locked by admins)
- Localize the lockout error on the frontend instead of displaying the backend's English `ProblemDetails.detail` directly
- Add i18n keys for both EN and CS

## Changes
- **Backend** (`ErrorMessages.cs`): Updated message to generic "Account is temporarily locked. Please try again later or contact an administrator."
- **Frontend** (`LoginForm.svelte`): Detect lockout response and map to localized i18n key
- **i18n** (`en.json`, `cs.json`): Added `auth_login_accountLocked` key

## Test plan
- [x] Backend build + all tests pass (453 passed)
- [x] Frontend format + lint + check pass (0 errors)
- [x] Login with locked account shows localized message in both EN and CS
- [x] Login with wrong credentials still shows "Invalid email or password"

🤖 Generated with [Claude Code](https://claude.com/claude-code)