### PR TITLE
fix(auth): use DataProtection tokens for email verification and password reset

### DIFF
--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Extensions/ServiceCollectionExtensions.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Extensions/ServiceCollectionExtensions.cs
@@ -57,9 +57,6 @@ public static class ServiceCollectionExtensions
                     opt.Lockout.MaxFailedAccessAttempts = 5;
                     opt.Lockout.AllowedForNewUsers = true;
 
-                    opt.Tokens.PasswordResetTokenProvider = TokenOptions.DefaultEmailProvider;
-                    opt.Tokens.EmailConfirmationTokenProvider = TokenOptions.DefaultEmailProvider;
-
                     opt.Tokens.AuthenticatorTokenProvider = TokenOptions.DefaultAuthenticatorProvider;
 
                 opt.User.RequireUniqueEmail = true;


### PR DESCRIPTION
## Summary
- `EmailConfirmationTokenProvider` and `PasswordResetTokenProvider` were set to `DefaultEmailProvider` (TOTP-based, ~15min validity)
- TOTP codes are designed for interactive 2FA, not email links where delivery time is unpredictable
- If email delivery was delayed even slightly, the TOTP expired before the user clicked the link → 400 error
- Switched to `DefaultProvider` (DataProtection) which uses the configured 24-hour lifespan

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (375 tests, 0 failures)
- [ ] Register new user → verify email link works within minutes
- [ ] Register new user → verify email link works after 1+ hour
- [ ] Password reset link works after delayed email delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)