### PR TITLE
feat(captcha): pass client IP and log error codes on Turnstile verification

### DIFF
--- a/src/backend/MyProject.Infrastructure/Features/Captcha/Extensions/ServiceCollectionExtensions.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Captcha/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
         /// <returns>The service collection for chaining.</returns>
         public IServiceCollection AddCaptchaServices()
         {
+            services.AddHttpContextAccessor();
             services.AddOptions<CaptchaOptions>()
                 .BindConfiguration(CaptchaOptions.SectionName)
                 .ValidateDataAnnotations()

--- a/src/backend/MyProject.Infrastructure/Features/Captcha/Services/TurnstileCaptchaService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Captcha/Services/TurnstileCaptchaService.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MyProject.Application.Features.Captcha;
@@ -13,6 +14,7 @@ namespace MyProject.Infrastructure.Features.Captcha.Services;
 internal sealed class TurnstileCaptchaService(
     HttpClient httpClient,
     IOptions<CaptchaOptions> options,
+    IHttpContextAccessor httpContextAccessor,
     ILogger<TurnstileCaptchaService> logger) : ICaptchaService
 {
     /// <inheritdoc />
@@ -20,12 +22,19 @@ internal sealed class TurnstileCaptchaService(
     {
         try
         {
-            var content = new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+            var formFields = new Dictionary<string, string>
             {
-                new("secret", options.Value.SecretKey),
-                new("response", token)
-            });
+                ["secret"] = options.Value.SecretKey,
+                ["response"] = token
+            };
 
+            var remoteIp = httpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+            if (remoteIp is not null)
+            {
+                formFields["remoteip"] = remoteIp;
+            }
+
+            using var content = new FormUrlEncodedContent(formFields);
             var response = await httpClient.PostAsync(options.Value.VerifyUrl, content, ct);
 
             if (!response.IsSuccessStatusCode)
@@ -35,7 +44,15 @@ internal sealed class TurnstileCaptchaService(
             }
 
             var json = await response.Content.ReadFromJsonAsync<TurnstileResponse>(ct);
-            return json?.Success is true;
+
+            if (json?.Success is not true)
+            {
+                logger.LogDebug("Turnstile rejected token with error codes: {ErrorCodes}",
+                    json?.ErrorCodes is { } codes ? string.Join(", ", codes) : "none");
+                return false;
+            }
+
+            return true;
         }
         catch (Exception ex)
         {
@@ -51,5 +68,8 @@ internal sealed class TurnstileCaptchaService(
     {
         [JsonPropertyName("success")]
         public bool Success { get; init; }
+
+        [JsonPropertyName("error-codes")]
+        public string[]? ErrorCodes { get; init; }
     }
 }


### PR DESCRIPTION
## Summary
- Pass `remoteip` to Cloudflare Turnstile siteverify for stronger token replay detection across different IPs
- Log Turnstile `error-codes` (e.g. `timeout-or-duplicate`, `invalid-input-response`) at Debug level for production troubleshooting via Seq

Closes #212, closes #213

## Test plan
- [ ] Verify Turnstile verification still works in local dev (with test keys)
- [ ] Check Seq logs show error codes when verification is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)