### PR TITLE
fix(avatar): add blob: to CSP and degrade S3 health check

### DIFF
--- a/src/backend/MyProject.WebApi/Extensions/HealthCheckExtensions.cs
+++ b/src/backend/MyProject.WebApi/Extensions/HealthCheckExtensions.cs
@@ -55,6 +55,7 @@ internal static class HealthCheckExtensions
         {
             healthChecks.AddCheck<S3HealthCheck>(
                 "S3",
+                failureStatus: HealthStatus.Degraded,
                 timeout: TimeSpan.FromSeconds(5),
                 tags: [ReadyTag]);
         }

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -230,7 +230,7 @@ const response = await fetch('/api/endpoint', { method: 'PUT', body: formData })
 
 ### CSP (svelte.config.js)
 
-Nonce-based `script-src`. `style-src: unsafe-inline` required for Svelte transitions. `img-src: self https: data:` for Vite-inlined assets. Cloudflare Turnstile needs `script-src` + `frame-src` for `challenges.cloudflare.com`.
+Nonce-based `script-src`. `style-src: unsafe-inline` required for Svelte transitions. `img-src: self https: data: blob:` — `data:` for Vite-inlined assets, `blob:` for `URL.createObjectURL()` previews (avatar upload). Cloudflare Turnstile needs `script-src` + `frame-src` for `challenges.cloudflare.com`.
 
 ### CSRF
 

--- a/src/frontend/svelte.config.js
+++ b/src/frontend/svelte.config.js
@@ -14,7 +14,7 @@ const config = {
 				'default-src': ['self'],
 				'script-src': ['self', 'nonce', 'https://challenges.cloudflare.com'],
 				'style-src': ['self', 'unsafe-inline'],
-				'img-src': ['self', 'https:', 'data:'],
+				'img-src': ['self', 'https:', 'data:', 'blob:'],
 				'font-src': ['self'],
 				'connect-src': ['self'],
 				'frame-src': ['https://challenges.cloudflare.com'],


### PR DESCRIPTION
## Summary
- Add `blob:` to CSP `img-src` directive — `URL.createObjectURL()` previews in the avatar upload dialog were blocked by Content Security Policy
- Change S3 health check `failureStatus` from `Unhealthy` to `Degraded` — S3 being temporarily unreachable shouldn't make `/health` return 503, the app still functions without file storage (just avatar uploads fail)
- Update AGENTS.md CSP documentation

## Breaking Changes
None

## Test Plan
- [ ] Upload avatar → preview shows in dialog (no CSP errors in console)
- [ ] Stop MinIO container → `/health` still returns 200 with status "Degraded" (not 503 "Unhealthy")
- [ ] `dotnet test` — 712 tests pass
- [ ] `pnpm run test && pnpm run lint && pnpm run check` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)