### PR TITLE
chore(deps): bump AWSSDK.S3 and Scalar.AspNetCore

### DIFF
--- a/src/backend/Directory.Packages.props
+++ b/src/backend/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(FrameworkVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.3.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.41" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.46" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(FrameworkVersion)" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -28,7 +28,7 @@
     <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.21.1" />
     <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
-    <PackageVersion Include="AWSSDK.S3" Version="3.7.415.1" />
+    <PackageVersion Include="AWSSDK.S3" Version="3.7.510.9" />
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- AWSSDK.S3: 3.7.415.1 → 3.7.510.9
- Scalar.AspNetCore: 2.12.41 → 2.12.46
- dotnet-ef 10.0.3 intentionally excluded (known bug)

Split from Dependabot PR #274 which bundled all three.

## Breaking Changes

None

## Test Plan

- [x] `dotnet build` passes
- [x] All 747 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)