### PR TITLE
refactor(email): extract email template name constants

### DIFF
--- a/src/backend/MyProject.Application/Features/Email/EmailTemplateNames.cs
+++ b/src/backend/MyProject.Application/Features/Email/EmailTemplateNames.cs
@@ -1,0 +1,19 @@
+namespace MyProject.Application.Features.Email;
+
+/// <summary>
+/// Constants for email template names used by <see cref="IEmailTemplateRenderer"/> and <see cref="ITemplatedEmailSender"/>.
+/// </summary>
+public static class EmailTemplateNames
+{
+    /// <summary>Email verification sent after registration.</summary>
+    public const string VerifyEmail = "verify-email";
+
+    /// <summary>Password reset requested by the user.</summary>
+    public const string ResetPassword = "reset-password";
+
+    /// <summary>Password reset initiated by an administrator.</summary>
+    public const string AdminResetPassword = "admin-reset-password";
+
+    /// <summary>Invitation to set a password for a newly created account.</summary>
+    public const string Invitation = "invitation";
+}

--- a/src/backend/MyProject.Application/Features/Email/IEmailTemplateRenderer.cs
+++ b/src/backend/MyProject.Application/Features/Email/IEmailTemplateRenderer.cs
@@ -9,7 +9,7 @@ public interface IEmailTemplateRenderer
     /// Renders the named email template with the given model.
     /// </summary>
     /// <typeparam name="TModel">The model type whose properties are exposed as template variables.</typeparam>
-    /// <param name="templateName">The template name (e.g. "verify-email") — without file extension.</param>
+    /// <param name="templateName">The template name from <see cref="EmailTemplateNames"/> — without file extension.</param>
     /// <param name="model">The model instance to bind into the template context.</param>
     /// <returns>A <see cref="RenderedEmail"/> containing subject, HTML body, and optional plain text body.</returns>
     RenderedEmail Render<TModel>(string templateName, TModel model) where TModel : class;

--- a/src/backend/MyProject.Application/Features/Email/ITemplatedEmailSender.cs
+++ b/src/backend/MyProject.Application/Features/Email/ITemplatedEmailSender.cs
@@ -11,7 +11,7 @@ public interface ITemplatedEmailSender
     /// Both rendering and delivery failures are logged but never propagated.
     /// </summary>
     /// <typeparam name="TModel">The template model type.</typeparam>
-    /// <param name="templateName">The template name (e.g. "verify-email") — without file extension.</param>
+    /// <param name="templateName">The template name from <see cref="EmailTemplateNames"/> — without file extension.</param>
     /// <param name="model">The model instance to bind into the template context.</param>
     /// <param name="to">The recipient email address.</param>
     /// <param name="cancellationToken">A cancellation token.</param>

--- a/src/backend/MyProject.Infrastructure/Features/Admin/Services/AdminService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Admin/Services/AdminService.cs
@@ -474,7 +474,7 @@ internal class AdminService(
         var resetUrl = $"{_emailOptions.FrontendBaseUrl.TrimEnd('/')}/reset-password?token={opaqueToken}";
 
         var model = new AdminResetPasswordModel(resetUrl, _emailTokenOptions.Lifetime.ToHumanReadable());
-        await templatedEmailSender.SendSafeAsync("admin-reset-password", model, email, cancellationToken);
+        await templatedEmailSender.SendSafeAsync(EmailTemplateNames.AdminResetPassword, model, email, cancellationToken);
 
         logger.LogInformation("Password reset email sent for user '{UserId}' by admin '{CallerUserId}'",
             userId, callerUserId);
@@ -527,7 +527,7 @@ internal class AdminService(
         var setPasswordUrl = $"{_emailOptions.FrontendBaseUrl.TrimEnd('/')}/reset-password?token={opaqueToken}&invited=1";
 
         var invitationModel = new InvitationModel(setPasswordUrl, _emailTokenOptions.Lifetime.ToHumanReadable());
-        await templatedEmailSender.SendSafeAsync("invitation", invitationModel, input.Email, cancellationToken);
+        await templatedEmailSender.SendSafeAsync(EmailTemplateNames.Invitation, invitationModel, input.Email, cancellationToken);
 
         logger.LogInformation("User '{UserId}' created via admin invitation for email '{Email}' by admin '{CallerUserId}'",
             user.Id, input.Email, callerUserId);

--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Services/AuthenticationService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Services/AuthenticationService.cs
@@ -314,7 +314,7 @@ internal class AuthenticationService(
         var resetUrl = $"{_emailOptions.FrontendBaseUrl.TrimEnd('/')}/reset-password?token={opaqueToken}";
 
         var model = new ResetPasswordModel(resetUrl, _emailTokenOptions.Lifetime.ToHumanReadable());
-        await templatedEmailSender.SendSafeAsync("reset-password", model, email, cancellationToken);
+        await templatedEmailSender.SendSafeAsync(EmailTemplateNames.ResetPassword, model, email, cancellationToken);
 
         await auditService.LogAsync(AuditActions.PasswordResetRequest, userId: user.Id, ct: cancellationToken);
 
@@ -490,7 +490,7 @@ internal class AuthenticationService(
         var verifyUrl = $"{_emailOptions.FrontendBaseUrl.TrimEnd('/')}/verify-email?token={opaqueToken}";
 
         var model = new VerifyEmailModel(verifyUrl);
-        await templatedEmailSender.SendSafeAsync("verify-email", model, user.Email, cancellationToken);
+        await templatedEmailSender.SendSafeAsync(EmailTemplateNames.VerifyEmail, model, user.Email, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add `EmailTemplateNames` constants class in the Application layer with all 4 template names (`VerifyEmail`, `ResetPassword`, `AdminResetPassword`, `Invitation`)
- Replace hardcoded template name strings in `AuthenticationService` and `AdminService` with constants
- Update XML docs on `IEmailTemplateRenderer` and `ITemplatedEmailSender` to reference `EmailTemplateNames`
- Tests intentionally keep hardcoded strings to act as a contract against accidental renames

## Breaking Changes
None

## Test Plan
- [x] All 779 backend tests pass (0 failures)
- [x] Verify tests still use hardcoded strings (contract tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)