### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Clean Architecture. Fully tested. Fully dockerized. API-first — use the includ
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/5rHquRptSh)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/fpindej/netrock)
 
 **[Live Demo](https://demo.netrock.dev)** · **[Documentation](#documentation)** · **[Quick Start](#quick-start)** · **[Discord](https://discord.gg/5rHquRptSh)**
 


### PR DESCRIPTION
## Summary
- Adds the DeepWiki badge to the README badge row, after the Discord badge

## Test plan
- [x] Verify badge renders correctly on GitHub
- [ ] Verify badge links to https://deepwiki.com/fpindej/netrock

🤖 Generated with [Claude Code](https://claude.com/claude-code)