### PR TITLE
fix(test): extract shared test utilities and fix infrastructure issues

### DIFF
--- a/src/frontend/src/lib/state/health.test.ts
+++ b/src/frontend/src/lib/state/health.test.ts
@@ -21,6 +21,12 @@ describe('health state', () => {
 
 	beforeEach(() => {
 		vi.useFakeTimers();
+		// Re-stub document before each test — afterEach's unstubAllGlobals removes it.
+		vi.stubGlobal('document', {
+			visibilityState: 'visible',
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn()
+		});
 		healthState.online = false;
 		healthState.checked = false;
 	});
@@ -28,6 +34,7 @@ describe('health state', () => {
 	afterEach(() => {
 		cleanup?.();
 		vi.useRealTimers();
+		vi.unstubAllGlobals();
 	});
 
 	it('starts unchecked', () => {

--- a/src/frontend/src/routes/(app)/layout.server.test.ts
+++ b/src/frontend/src/routes/(app)/layout.server.test.ts
@@ -15,45 +15,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { isHttpError, isRedirect } from '@sveltejs/kit';
 import { load } from './+layout.server';
+import { MOCK_USER, createMockLoadEvent } from '../../test-utils';
 
 type LoadEvent = Parameters<typeof load>[0];
-
-const MOCK_USER = {
-	id: '00000000-0000-0000-0000-000000000001',
-	username: 'test@example.com',
-	email: 'test@example.com',
-	firstName: 'Test',
-	lastName: 'User',
-	roles: ['User'],
-	permissions: [],
-	emailConfirmed: true
-};
-
-/** Stubs for all `ServerLoadEvent` properties the load function does NOT use. */
-const EVENT_DEFAULTS = {
-	cookies: {
-		get: vi.fn(),
-		getAll: vi.fn(() => []),
-		set: vi.fn(),
-		delete: vi.fn(),
-		serialize: vi.fn()
-	},
-	fetch: vi.fn() as typeof fetch,
-	getClientAddress: () => '127.0.0.1',
-	locals: { user: null, locale: 'en' },
-	params: {},
-	platform: undefined,
-	request: new Request('http://localhost'),
-	route: { id: '/(app)' },
-	setHeaders: vi.fn(),
-	url: new URL('http://localhost'),
-	isDataRequest: false,
-	isSubRequest: false,
-	isRemoteRequest: false,
-	tracing: { enabled: false, root: {}, current: {} },
-	depends: vi.fn(),
-	untrack: <T>(fn: () => T): T => fn()
-};
 
 /** Builds a complete mock SvelteKit load event for the (app) layout. */
 function mockLoadEvent(
@@ -65,10 +29,10 @@ function mockLoadEvent(
 ) {
 	const { user = null, backendError = null, hadSession = false } = overrides;
 
-	return {
-		...EVENT_DEFAULTS,
+	return createMockLoadEvent({
+		route: { id: '/(app)' },
 		parent: vi.fn().mockResolvedValue({ user, backendError, hadSession })
-	} as LoadEvent;
+	}) as LoadEvent;
 }
 
 /** Asserts that a load function throws a SvelteKit redirect. */

--- a/src/frontend/src/routes/(public)/login/page.server.test.ts
+++ b/src/frontend/src/routes/(public)/login/page.server.test.ts
@@ -1,44 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { isRedirect } from '@sveltejs/kit';
 import { load } from './+page.server';
+import { MOCK_USER, createMockLoadEvent } from '../../../test-utils';
 
 type LoadEvent = Parameters<typeof load>[0];
-
-const MOCK_USER = {
-	id: '00000000-0000-0000-0000-000000000001',
-	username: 'test@example.com',
-	email: 'test@example.com',
-	firstName: 'Test',
-	lastName: 'User',
-	roles: ['User'],
-	permissions: [],
-	emailConfirmed: true
-};
-
-/** Stubs for all `ServerLoadEvent` properties the load function does NOT use. */
-const EVENT_DEFAULTS = {
-	cookies: {
-		get: vi.fn(),
-		getAll: vi.fn(() => []),
-		set: vi.fn(),
-		delete: vi.fn(),
-		serialize: vi.fn()
-	},
-	fetch: vi.fn() as typeof fetch,
-	getClientAddress: () => '127.0.0.1',
-	locals: { user: null, locale: 'en' },
-	params: {},
-	platform: undefined,
-	request: new Request('http://localhost'),
-	route: { id: '/(public)/login' },
-	setHeaders: vi.fn(),
-	isDataRequest: false,
-	isSubRequest: false,
-	isRemoteRequest: false,
-	tracing: { enabled: false, root: {}, current: {} },
-	depends: vi.fn(),
-	untrack: <T>(fn: () => T): T => fn()
-};
 
 /** Builds a complete mock SvelteKit load event for the login page. */
 function mockLoadEvent(
@@ -54,11 +19,11 @@ function mockLoadEvent(
 		url.searchParams.set(key, value);
 	}
 
-	return {
-		...EVENT_DEFAULTS,
+	return createMockLoadEvent({
+		route: { id: '/(public)/login' },
 		parent: vi.fn().mockResolvedValue({ user }),
 		url
-	} as LoadEvent;
+	}) as LoadEvent;
 }
 
 describe('login page server load', () => {

--- a/src/frontend/src/routes/layout.server.test.ts
+++ b/src/frontend/src/routes/layout.server.test.ts
@@ -7,6 +7,7 @@
  * sends Set-Cookie headers (e.g. clearing the token on failed refresh).
  */
 import { describe, expect, it, vi } from 'vitest';
+import { MOCK_USER, createMockLoadEvent, createMockCookies } from '../test-utils';
 
 vi.mock('$app/environment', () => ({ dev: false }));
 vi.mock('$lib/config/server', () => ({ SERVER_CONFIG: { API_URL: '' } }));
@@ -27,48 +28,12 @@ const { REFRESH_TOKEN_COOKIE } = await import('$lib/auth');
 
 type LoadEvent = Parameters<typeof load>[0];
 
-const MOCK_USER = {
-	id: '00000000-0000-0000-0000-000000000001',
-	username: 'test@example.com',
-	email: 'test@example.com',
-	firstName: 'Test',
-	lastName: 'User',
-	roles: ['User'],
-	permissions: [],
-	emailConfirmed: true
-};
-
-/** Stubs for ServerLoadEvent properties. */
-const EVENT_DEFAULTS = {
-	fetch: vi.fn() as typeof fetch,
-	getClientAddress: () => '127.0.0.1',
-	locals: { user: null, locale: 'en' },
-	params: {},
-	parent: vi.fn().mockResolvedValue({}),
-	platform: undefined,
-	request: new Request('http://localhost'),
-	route: { id: '/' },
-	setHeaders: vi.fn(),
-	isDataRequest: false,
-	isSubRequest: false,
-	isRemoteRequest: false,
-	tracing: { enabled: false, root: {}, current: {} },
-	depends: vi.fn(),
-	untrack: <T>(fn: () => T): T => fn()
-};
-
 function mockLoadEvent(cookieValue?: string) {
-	return {
-		...EVENT_DEFAULTS,
-		url: new URL('http://localhost'),
-		cookies: {
-			get: vi.fn((name: string) => (name === REFRESH_TOKEN_COOKIE ? cookieValue : undefined)),
-			getAll: vi.fn(() => []),
-			set: vi.fn(),
-			delete: vi.fn(),
-			serialize: vi.fn()
-		}
-	} as LoadEvent;
+	return createMockLoadEvent({
+		cookies: createMockCookies((name: string) =>
+			name === REFRESH_TOKEN_COOKIE ? cookieValue : undefined
+		)
+	}) as LoadEvent;
 }
 
 /** Narrows away the `void` branch of the load return type. */

--- a/src/frontend/src/test-utils.ts
+++ b/src/frontend/src/test-utils.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared test utilities for SvelteKit server load function tests.
+ *
+ * Provides a mock user constant and a factory for building mock ServerLoadEvent
+ * objects, eliminating duplication across route-level test files.
+ */
+import { vi } from 'vitest';
+
+/** A realistic user object matching the shape returned by getUser(). */
+export const MOCK_USER = {
+	id: '00000000-0000-0000-0000-000000000001',
+	username: 'test@example.com',
+	email: 'test@example.com',
+	firstName: 'Test',
+	lastName: 'User',
+	roles: ['User'],
+	permissions: [],
+	emailConfirmed: true
+} as const;
+
+/**
+ * Default stubs for ServerLoadEvent properties that most load functions ignore.
+ *
+ * Individual tests override specific properties via `createMockLoadEvent()`.
+ * Note: `cookies`, `parent`, and `url` are intentionally omitted here because
+ * they vary per test and should always be provided explicitly.
+ */
+const EVENT_DEFAULTS = {
+	fetch: vi.fn() as typeof fetch,
+	getClientAddress: () => '127.0.0.1',
+	locals: { user: null, locale: 'en' },
+	params: {},
+	platform: undefined,
+	request: new Request('http://localhost'),
+	route: { id: '/' },
+	setHeaders: vi.fn(),
+	isDataRequest: false,
+	isSubRequest: false,
+	isRemoteRequest: false,
+	tracing: { enabled: false, root: {}, current: {} },
+	depends: vi.fn(),
+	untrack: <T>(fn: () => T): T => fn()
+};
+
+/** Creates a mock cookies object with vi.fn() stubs for all methods. */
+export function createMockCookies(getFn?: (name: string) => string | undefined) {
+	return {
+		get: vi.fn(getFn ?? (() => undefined)),
+		getAll: vi.fn(() => []),
+		set: vi.fn(),
+		delete: vi.fn(),
+		serialize: vi.fn()
+	};
+}
+
+/**
+ * Builds a mock SvelteKit ServerLoadEvent with sensible defaults.
+ *
+ * Every property can be overridden. Properties not provided fall back to
+ * EVENT_DEFAULTS, with `url` defaulting to `http://localhost` and `cookies`
+ * defaulting to a no-op mock set, and `parent` defaulting to resolving `{}`.
+ *
+ * @example
+ * ```ts
+ * const event = createMockLoadEvent({
+ *   parent: vi.fn().mockResolvedValue({ user: MOCK_USER }),
+ *   url: new URL('http://localhost/login?reason=session_expired')
+ * });
+ * ```
+ */
+export function createMockLoadEvent(overrides: Record<string, unknown> = {}) {
+	return {
+		...EVENT_DEFAULTS,
+		url: new URL('http://localhost'),
+		cookies: createMockCookies(),
+		parent: vi.fn().mockResolvedValue({}),
+		...overrides
+	};
+}

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
 		include: ['src/**/*.test.ts'],
 		environment: 'node',
 		setupFiles: ['src/test-setup.ts'],
-		restoreMocks: true,
-		passWithNoTests: true
+		restoreMocks: true
 	}
 });


### PR DESCRIPTION
## Summary
- Extract duplicated `MOCK_USER` and `EVENT_DEFAULTS` from 3 test files into a shared `src/frontend/src/test-utils.ts` module with `createMockLoadEvent()` factory and `createMockCookies()` helper
- Fix `vi.stubGlobal` leak in `health.test.ts` by adding `vi.unstubAllGlobals()` in `afterEach` (and re-stubbing `document` in `beforeEach` since the cleanup removes it between tests)
- Remove `passWithNoTests: true` from vitest config — the project now has 217 tests across 10 test files, so this safety net is no longer needed and would mask accidental test deletion

Closes #300

## Test plan
- [x] All 217 tests pass (`pnpm run test`)
- [x] `svelte-check` passes with 0 errors
- [x] ESLint + Prettier pass
- [x] Verified health tests properly clean up global stubs between test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)