### PR TITLE
test(frontend): add mutation, admin guard, and hooks.server tests

### DIFF
--- a/src/frontend/src/hooks.server.test.ts
+++ b/src/frontend/src/hooks.server.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for the SvelteKit server hooks — security headers and API proxy bypass.
+ *
+ * The handle function applies security headers to all page responses but
+ * skips them for API proxy routes (/api/*) where the backend sets its own.
+ * HSTS is only applied in production mode.
+ *
+ * The paraglide middleware is mocked to pass through directly so these tests
+ * focus on the security header logic.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Handle, RequestEvent, ResolveOptions } from '@sveltejs/kit';
+
+/** The expected security headers on every page response. */
+const EXPECTED_HEADERS: Record<string, string> = {
+	'X-Content-Type-Options': 'nosniff',
+	'X-Frame-Options': 'DENY',
+	'Referrer-Policy': 'strict-origin-when-cross-origin',
+	'Permissions-Policy': 'camera=(), microphone=(), geolocation=()'
+};
+
+const HSTS_VALUE = 'max-age=63072000; includeSubDomains; preload';
+
+vi.mock('$lib/paraglide/server', () => ({
+	paraglideMiddleware: vi.fn(
+		(_request: Request, resolve: (args: { locale: string }) => Response | Promise<Response>) =>
+			resolve({ locale: 'en' })
+	)
+}));
+
+vi.mock('$lib/paraglide/runtime', () => ({
+	extractLocaleFromHeader: vi.fn(() => null),
+	cookieName: 'PARAGLIDE_LOCALE',
+	baseLocale: 'en'
+}));
+
+/** Creates a minimal mock RequestEvent for the handle function. */
+function mockRequestEvent(pathname: string): RequestEvent {
+	const url = new URL(`http://localhost${pathname}`);
+	return {
+		url,
+		request: new Request(url),
+		cookies: {
+			get: vi.fn(() => undefined),
+			getAll: vi.fn(() => []),
+			set: vi.fn(),
+			delete: vi.fn(),
+			serialize: vi.fn()
+		},
+		locals: { user: null, locale: 'en' },
+		params: {},
+		platform: undefined,
+		route: { id: pathname },
+		getClientAddress: () => '127.0.0.1',
+		setHeaders: vi.fn(),
+		isDataRequest: false,
+		isSubRequest: false,
+		isRemoteRequest: false,
+		fetch: vi.fn() as typeof fetch
+	} as unknown as RequestEvent;
+}
+
+/** Creates a mock resolve function that returns a basic HTML response. */
+function mockResolve(): (event: RequestEvent, opts?: ResolveOptions) => Promise<Response> {
+	return vi.fn(async (_event: RequestEvent, opts?: ResolveOptions) => {
+		let html = '<html lang="%lang%"><body>test</body></html>';
+		if (opts?.transformPageChunk) {
+			html = opts.transformPageChunk({ html, done: true }) as string;
+		}
+		return new Response(html, {
+			status: 200,
+			headers: { 'Content-Type': 'text/html' }
+		});
+	});
+}
+
+describe('hooks.server handle — production mode (dev: false)', () => {
+	let handle: Handle;
+
+	beforeEach(async () => {
+		vi.resetModules();
+
+		vi.doMock('$app/environment', () => ({
+			browser: false,
+			dev: false,
+			building: false,
+			version: 'test'
+		}));
+
+		vi.doMock('$lib/paraglide/server', () => ({
+			paraglideMiddleware: vi.fn(
+				(_request: Request, resolve: (args: { locale: string }) => Response | Promise<Response>) =>
+					resolve({ locale: 'en' })
+			)
+		}));
+
+		vi.doMock('$lib/paraglide/runtime', () => ({
+			extractLocaleFromHeader: vi.fn(() => null),
+			cookieName: 'PARAGLIDE_LOCALE',
+			baseLocale: 'en'
+		}));
+
+		const mod = await import('./hooks.server');
+		handle = mod.handle;
+	});
+
+	// ── Security headers on page responses ──────────────────────────
+
+	it('page response — includes X-Content-Type-Options', async () => {
+		const response = await handle({
+			event: mockRequestEvent('/dashboard'),
+			resolve: mockResolve()
+		});
+		expect(response.headers.get('X-Content-Type-Options')).toBe(
+			EXPECTED_HEADERS['X-Content-Type-Options']
+		);
+	});
+
+	it('page response — includes X-Frame-Options', async () => {
+		const response = await handle({
+			event: mockRequestEvent('/dashboard'),
+			resolve: mockResolve()
+		});
+		expect(response.headers.get('X-Frame-Options')).toBe(EXPECTED_HEADERS['X-Frame-Options']);
+	});
+
+	it('page response — includes Referrer-Policy', async () => {
+		const response = await handle({
+			event: mockRequestEvent('/dashboard'),
+			resolve: mockResolve()
+		});
+		expect(response.headers.get('Referrer-Policy')).toBe(EXPECTED_HEADERS['Referrer-Policy']);
+	});
+
+	it('page response — includes Permissions-Policy', async () => {
+		const response = await handle({
+			event: mockRequestEvent('/dashboard'),
+			resolve: mockResolve()
+		});
+		expect(response.headers.get('Permissions-Policy')).toBe(EXPECTED_HEADERS['Permissions-Policy']);
+	});
+
+	it('page response — includes all expected security headers', async () => {
+		const response = await handle({ event: mockRequestEvent('/'), resolve: mockResolve() });
+		for (const [header, value] of Object.entries(EXPECTED_HEADERS)) {
+			expect(response.headers.get(header)).toBe(value);
+		}
+	});
+
+	// ── HSTS in production ──────────────────────────────────────────
+
+	it('production mode — includes HSTS header', async () => {
+		const response = await handle({ event: mockRequestEvent('/'), resolve: mockResolve() });
+		expect(response.headers.get('Strict-Transport-Security')).toBe(HSTS_VALUE);
+	});
+
+	// ── API proxy bypass ────────────────────────────────────────────
+
+	it('/api route — does not add security headers', async () => {
+		const resolve = mockResolve();
+		const response = await handle({ event: mockRequestEvent('/api/v1/users'), resolve });
+		expect(response.headers.get('X-Content-Type-Options')).toBeNull();
+		expect(response.headers.get('X-Frame-Options')).toBeNull();
+		expect(response.headers.get('Referrer-Policy')).toBeNull();
+		expect(response.headers.get('Permissions-Policy')).toBeNull();
+		expect(response.headers.get('Strict-Transport-Security')).toBeNull();
+	});
+
+	it('/api root — does not add security headers', async () => {
+		const resolve = mockResolve();
+		const response = await handle({ event: mockRequestEvent('/api'), resolve });
+		expect(response.headers.get('X-Content-Type-Options')).toBeNull();
+	});
+
+	it('/api route — calls resolve directly without paraglide middleware', async () => {
+		const resolve = mockResolve();
+		await handle({ event: mockRequestEvent('/api/v1/health'), resolve });
+		expect(resolve).toHaveBeenCalledOnce();
+	});
+
+	// ── Non-API routes still get headers ────────────────────────────
+
+	it('root path — gets security headers', async () => {
+		const response = await handle({ event: mockRequestEvent('/'), resolve: mockResolve() });
+		expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+	});
+
+	it('/login path — gets security headers', async () => {
+		const response = await handle({ event: mockRequestEvent('/login'), resolve: mockResolve() });
+		expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+	});
+
+	it('/admin path — gets security headers', async () => {
+		const response = await handle({ event: mockRequestEvent('/admin'), resolve: mockResolve() });
+		expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+	});
+
+	// ── Locale handling ─────────────────────────────────────────────
+
+	it('page response — replaces %lang% with locale', async () => {
+		const response = await handle({ event: mockRequestEvent('/'), resolve: mockResolve() });
+		const html = await response.text();
+		expect(html).toContain('lang="en"');
+		expect(html).not.toContain('%lang%');
+	});
+
+	it('page response — sets locals.locale', async () => {
+		const event = mockRequestEvent('/');
+		await handle({ event, resolve: mockResolve() });
+		expect(event.locals.locale).toBe('en');
+	});
+
+	it('page response — sets locals.user to null', async () => {
+		const event = mockRequestEvent('/');
+		await handle({ event, resolve: mockResolve() });
+		expect(event.locals.user).toBeNull();
+	});
+});
+
+describe('hooks.server handle — dev mode (dev: true)', () => {
+	let handle: Handle;
+
+	beforeEach(async () => {
+		vi.resetModules();
+
+		vi.doMock('$app/environment', () => ({
+			browser: false,
+			dev: true,
+			building: false,
+			version: 'test'
+		}));
+
+		vi.doMock('$lib/paraglide/server', () => ({
+			paraglideMiddleware: vi.fn(
+				(_request: Request, resolve: (args: { locale: string }) => Response | Promise<Response>) =>
+					resolve({ locale: 'en' })
+			)
+		}));
+
+		vi.doMock('$lib/paraglide/runtime', () => ({
+			extractLocaleFromHeader: vi.fn(() => null),
+			cookieName: 'PARAGLIDE_LOCALE',
+			baseLocale: 'en'
+		}));
+
+		const mod = await import('./hooks.server');
+		handle = mod.handle;
+	});
+
+	it('dev mode — does not include HSTS header', async () => {
+		const response = await handle({ event: mockRequestEvent('/'), resolve: mockResolve() });
+		expect(response.headers.get('Strict-Transport-Security')).toBeNull();
+	});
+
+	it('dev mode — still includes other security headers', async () => {
+		const response = await handle({ event: mockRequestEvent('/'), resolve: mockResolve() });
+		expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+		expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+		expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+		expect(response.headers.get('Permissions-Policy')).toBe(
+			'camera=(), microphone=(), geolocation=()'
+		);
+	});
+});

--- a/src/frontend/src/lib/api/mutation.test.ts
+++ b/src/frontend/src/lib/api/mutation.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for handleMutationError — the orchestrator that routes mutation failures
+ * to the appropriate UI response (rate-limit toast, validation error mapping,
+ * or generic error toast).
+ *
+ * The underlying utilities (isRateLimited, mapFieldErrors, etc.) are tested
+ * in error-handling.test.ts; these tests focus on the branching and delegation logic.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { handleMutationError, type MutationErrorOptions } from './mutation';
+
+vi.mock('$lib/components/ui/sonner', () => ({
+	toast: {
+		error: vi.fn(),
+		success: vi.fn()
+	}
+}));
+
+vi.mock('$lib/paraglide/messages', () => ({
+	error_rateLimited: vi.fn(() => 'Too many requests'),
+	error_rateLimitedDescription: vi.fn(() => 'Please try again later.'),
+	error_rateLimitedDescriptionWithRetry: vi.fn(
+		({ seconds }: { seconds: number }) => `Please wait ${seconds} seconds and try again.`
+	)
+}));
+
+import { toast } from '$lib/components/ui/sonner';
+
+/** Creates a Response with the given status and optional Retry-After header. */
+function mockResponse(status: number, retryAfter?: string): Response {
+	const headers: Record<string, string> = {};
+	if (retryAfter !== undefined) {
+		headers['Retry-After'] = retryAfter;
+	}
+	return new Response(null, { status, headers });
+}
+
+/** Creates default MutationErrorOptions with a spy cooldown. */
+function defaultOptions(overrides: Partial<MutationErrorOptions> = {}): MutationErrorOptions {
+	return {
+		cooldown: { start: vi.fn() },
+		fallback: 'Something went wrong',
+		...overrides
+	};
+}
+
+// ── 502/503 suppression ─────────────────────────────────────────────
+
+describe('handleMutationError — 502/503 suppression', () => {
+	it('502 status — suppresses toast entirely', () => {
+		const options = defaultOptions();
+		handleMutationError(mockResponse(502), null, options);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('503 status — suppresses toast entirely', () => {
+		const options = defaultOptions();
+		handleMutationError(mockResponse(503), null, options);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('502 status — does not call onError', () => {
+		const onError = vi.fn();
+		handleMutationError(mockResponse(502), null, defaultOptions({ onError }));
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('503 status — does not call onRateLimited', () => {
+		const onRateLimited = vi.fn();
+		handleMutationError(mockResponse(503), null, defaultOptions({ onRateLimited }));
+		expect(onRateLimited).not.toHaveBeenCalled();
+	});
+});
+
+// ── 429 rate-limit path ─────────────────────────────────────────────
+
+describe('handleMutationError — 429 rate-limit', () => {
+	it('429 with Retry-After — starts cooldown with parsed seconds', () => {
+		const options = defaultOptions();
+		handleMutationError(mockResponse(429, '30'), null, options);
+		expect(options.cooldown.start).toHaveBeenCalledWith(30);
+	});
+
+	it('429 with Retry-After — shows rate-limit toast with retry description', () => {
+		handleMutationError(mockResponse(429, '30'), null, defaultOptions());
+		expect(toast.error).toHaveBeenCalledWith('Too many requests', {
+			description: 'Please wait 30 seconds and try again.'
+		});
+	});
+
+	it('429 without Retry-After — shows rate-limit toast with generic description', () => {
+		handleMutationError(mockResponse(429), null, defaultOptions());
+		expect(toast.error).toHaveBeenCalledWith('Too many requests', {
+			description: 'Please try again later.'
+		});
+	});
+
+	it('429 without Retry-After — does not start cooldown', () => {
+		const options = defaultOptions();
+		handleMutationError(mockResponse(429), null, options);
+		expect(options.cooldown.start).not.toHaveBeenCalled();
+	});
+
+	it('429 with onRateLimited callback — calls it after toast', () => {
+		const onRateLimited = vi.fn();
+		handleMutationError(mockResponse(429, '10'), null, defaultOptions({ onRateLimited }));
+		expect(onRateLimited).toHaveBeenCalledOnce();
+	});
+
+	it('429 without onRateLimited — does not throw', () => {
+		expect(() => {
+			handleMutationError(mockResponse(429, '10'), null, defaultOptions());
+		}).not.toThrow();
+	});
+});
+
+// ── Validation error path ───────────────────────────────────────────
+
+describe('handleMutationError — validation errors', () => {
+	it('validation error with onValidationError — calls handler with mapped field errors', () => {
+		const onValidationError = vi.fn();
+		const error = {
+			title: 'Validation failed',
+			status: 422,
+			errors: { Email: ['Required'], FirstName: ['Too short'] }
+		};
+		handleMutationError(mockResponse(422), error, defaultOptions({ onValidationError }));
+		expect(onValidationError).toHaveBeenCalledWith({
+			email: 'Required',
+			firstName: 'Too short'
+		});
+	});
+
+	it('validation error with onValidationError — does not show toast', () => {
+		const onValidationError = vi.fn();
+		const error = { errors: { Email: ['Required'] } };
+		handleMutationError(mockResponse(422), error, defaultOptions({ onValidationError }));
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('validation error without onValidationError — falls through to generic error', () => {
+		const error = { errors: { Email: ['Required'] }, detail: 'Validation failed' };
+		handleMutationError(mockResponse(422), error, defaultOptions());
+		expect(toast.error).toHaveBeenCalledWith('Validation failed');
+	});
+
+	it('non-validation error with onValidationError — falls through to generic error', () => {
+		const onValidationError = vi.fn();
+		const error = { detail: 'Not found' };
+		handleMutationError(mockResponse(404), error, defaultOptions({ onValidationError }));
+		expect(onValidationError).not.toHaveBeenCalled();
+		expect(toast.error).toHaveBeenCalledWith('Not found');
+	});
+});
+
+// ── Generic error path ──────────────────────────────────────────────
+
+describe('handleMutationError — generic errors', () => {
+	it('generic error without onError — shows toast with error message', () => {
+		const error = { detail: 'Invalid credentials' };
+		handleMutationError(mockResponse(401), error, defaultOptions());
+		expect(toast.error).toHaveBeenCalledWith('Invalid credentials');
+	});
+
+	it('generic error without detail — shows toast with fallback message', () => {
+		handleMutationError(mockResponse(500), {}, defaultOptions({ fallback: 'Save failed' }));
+		expect(toast.error).toHaveBeenCalledWith('Save failed');
+	});
+
+	it('generic error with onError — calls onError instead of toast', () => {
+		const onError = vi.fn();
+		handleMutationError(mockResponse(400), { detail: 'Bad request' }, defaultOptions({ onError }));
+		expect(onError).toHaveBeenCalledOnce();
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('null error — shows toast with fallback', () => {
+		handleMutationError(mockResponse(500), null, defaultOptions({ fallback: 'Unexpected error' }));
+		expect(toast.error).toHaveBeenCalledWith('Unexpected error');
+	});
+});

--- a/src/frontend/src/routes/(app)/admin/layout.server.test.ts
+++ b/src/frontend/src/routes/(app)/admin/layout.server.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the admin layout server guard — the permission boundary for admin routes.
+ *
+ * The admin layout requires at least one of: users.view, roles.view, or jobs.view.
+ * Users without any of these permissions are redirected to /.
+ *
+ * Follows the same pattern as the parent (app) layout test.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { isRedirect } from '@sveltejs/kit';
+import { load } from './+layout.server';
+
+type LoadEvent = Parameters<typeof load>[0];
+
+const MOCK_ADMIN_USER = {
+	id: '00000000-0000-0000-0000-000000000001',
+	username: 'admin@example.com',
+	email: 'admin@example.com',
+	firstName: 'Admin',
+	lastName: 'User',
+	roles: ['Admin'],
+	permissions: ['users.view', 'roles.view', 'jobs.view'],
+	emailConfirmed: true
+};
+
+const MOCK_REGULAR_USER = {
+	id: '00000000-0000-0000-0000-000000000002',
+	username: 'user@example.com',
+	email: 'user@example.com',
+	firstName: 'Regular',
+	lastName: 'User',
+	roles: ['User'],
+	permissions: [],
+	emailConfirmed: true
+};
+
+const MOCK_SUPERADMIN_USER = {
+	id: '00000000-0000-0000-0000-000000000003',
+	username: 'superadmin@example.com',
+	email: 'superadmin@example.com',
+	firstName: 'Super',
+	lastName: 'Admin',
+	roles: ['SuperAdmin'],
+	permissions: [],
+	emailConfirmed: true
+};
+
+/** Stubs for all `ServerLoadEvent` properties the load function does NOT use. */
+const EVENT_DEFAULTS = {
+	cookies: {
+		get: vi.fn(),
+		getAll: vi.fn(() => []),
+		set: vi.fn(),
+		delete: vi.fn(),
+		serialize: vi.fn()
+	},
+	fetch: vi.fn() as typeof fetch,
+	getClientAddress: () => '127.0.0.1',
+	locals: { user: null, locale: 'en' },
+	params: {},
+	platform: undefined,
+	request: new Request('http://localhost'),
+	route: { id: '/(app)/admin' },
+	setHeaders: vi.fn(),
+	url: new URL('http://localhost/admin'),
+	isDataRequest: false,
+	isSubRequest: false,
+	isRemoteRequest: false,
+	tracing: { enabled: false, root: {}, current: {} },
+	depends: vi.fn(),
+	untrack: <T>(fn: () => T): T => fn()
+};
+
+/** Builds a complete mock SvelteKit load event for the admin layout. */
+function mockLoadEvent(
+	user: typeof MOCK_ADMIN_USER | typeof MOCK_REGULAR_USER | typeof MOCK_SUPERADMIN_USER
+) {
+	return {
+		...EVENT_DEFAULTS,
+		parent: vi.fn().mockResolvedValue({ user })
+	} as LoadEvent;
+}
+
+/** Asserts that a load function throws a SvelteKit redirect. */
+async function expectRedirect(fn: () => ReturnType<typeof load>, status: number, location: string) {
+	try {
+		await fn();
+		expect.fail('Expected redirect to be thrown');
+	} catch (e) {
+		expect(isRedirect(e)).toBe(true);
+		if (isRedirect(e)) {
+			expect(e.status).toBe(status);
+			expect(e.location).toBe(location);
+		}
+	}
+}
+
+describe('admin layout server load', () => {
+	// ── Allowed access ──────────────────────────────────────────────
+
+	it('user with all admin permissions — returns user data', async () => {
+		const result = await load(mockLoadEvent(MOCK_ADMIN_USER));
+		expect(result).toEqual({ user: MOCK_ADMIN_USER });
+	});
+
+	it('user with only users.view — returns user data', async () => {
+		const user = { ...MOCK_REGULAR_USER, permissions: ['users.view'] };
+		const result = await load(mockLoadEvent(user));
+		expect(result).toEqual({ user });
+	});
+
+	it('user with only roles.view — returns user data', async () => {
+		const user = { ...MOCK_REGULAR_USER, permissions: ['roles.view'] };
+		const result = await load(mockLoadEvent(user));
+		expect(result).toEqual({ user });
+	});
+
+	it('user with only jobs.view — returns user data', async () => {
+		const user = { ...MOCK_REGULAR_USER, permissions: ['jobs.view'] };
+		const result = await load(mockLoadEvent(user));
+		expect(result).toEqual({ user });
+	});
+
+	it('SuperAdmin without explicit permissions — returns user data (implicit all)', async () => {
+		const result = await load(mockLoadEvent(MOCK_SUPERADMIN_USER));
+		expect(result).toEqual({ user: MOCK_SUPERADMIN_USER });
+	});
+
+	// ── Denied access ───────────────────────────────────────────────
+
+	it('user without admin permissions — redirects to /', async () => {
+		await expectRedirect(() => load(mockLoadEvent(MOCK_REGULAR_USER)), 303, '/');
+	});
+
+	it('user with unrelated permissions — redirects to /', async () => {
+		const user = { ...MOCK_REGULAR_USER, permissions: ['some.other.permission'] };
+		await expectRedirect(() => load(mockLoadEvent(user)), 303, '/');
+	});
+});


### PR DESCRIPTION
## Summary
- Add tests for `handleMutationError` in `mutation.ts`: 502/503 suppression, 429 rate-limit path with/without Retry-After, validation error mapping, and generic error fallback
- Add tests for the admin layout server guard: permission checks for users.view, roles.view, jobs.view, SuperAdmin implicit access, and redirect on denied access
- Add tests for `hooks.server.ts`: security headers present on page responses, absent on `/api` routes, HSTS only in production mode, locale handling

Closes #299

## Test plan
- [x] All 259 tests pass (13 test files, 42 new tests across 3 files)
- [x] `pnpm run check` passes with 0 errors
- [x] `pnpm run lint` passes
- [x] `pnpm run format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)