### PR TITLE
fix(otel): enable structured logs in Aspire dashboard

### DIFF
--- a/src/backend/MyProject.ServiceDefaults/Extensions.cs
+++ b/src/backend/MyProject.ServiceDefaults/Extensions.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -39,18 +38,21 @@ public static class Extensions
     }
 
     /// <summary>
-    /// Configures OpenTelemetry metrics and tracing with OTLP export.
+    /// Configures OpenTelemetry logging, metrics, and tracing with OTLP export.
+    /// All three signals are registered on the <see cref="OpenTelemetryBuilder"/> pipeline
+    /// so that <see cref="OpenTelemetryBuilderExtensions.UseOtlpExporter"/> configures export for all of them.
     /// When <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is not set (standalone run), the OTLP exporter is a no-op.
     /// </summary>
     private static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
     {
-        builder.Logging.AddOpenTelemetry(logging =>
-        {
-            logging.IncludeFormattedMessage = true;
-            logging.IncludeScopes = true;
-        });
-
         builder.Services.AddOpenTelemetry()
+            .WithLogging(
+                configureBuilder: null,
+                configureOptions: options =>
+                {
+                    options.IncludeFormattedMessage = true;
+                    options.IncludeScopes = true;
+                })
             .WithMetrics(metrics =>
             {
                 metrics.AddAspNetCoreInstrumentation()

--- a/src/backend/MyProject.WebApi/Program.cs
+++ b/src/backend/MyProject.WebApi/Program.cs
@@ -34,7 +34,7 @@ try
     builder.Host.UseSerilog((context, _, loggerConfiguration) =>
     {
         LoggerConfigurationExtensions.SetupLogger(context.Configuration, loggerConfiguration);
-    }, true);
+    }, preserveStaticLogger: true, writeToProviders: true);
 
     Log.Debug("Adding Aspire service defaults (OpenTelemetry, service discovery, resilience)");
     builder.AddServiceDefaults();


### PR DESCRIPTION
## Summary

Two issues preventing structured logs from appearing in the Aspire dashboard:

1. **ServiceDefaults**: `builder.Logging.AddOpenTelemetry()` registered the OTEL logging provider via the `ILoggingBuilder` path, but `UseOtlpExporter()` only configures export for signals on the `OpenTelemetryBuilder`. Replaced with `.WithLogging()` so all three signals (logs, metrics, traces) flow through the same pipeline.

2. **Program.cs**: `UseSerilog(..., true)` mapped `true` to `preserveStaticLogger`, not `writeToProviders` (positional arg bug). `writeToProviders` defaulted to `false`, so Serilog never forwarded logs to the OTEL provider. Fixed with named parameters: `preserveStaticLogger: true, writeToProviders: true`.

## Breaking Changes

None.

## Test Plan

- [x] `dotnet build && dotnet test` all green
- [x] Run Aspire, trigger some actions, verify "Structured logs" tab shows entries