### PR TITLE
fix(auth): tighten OAuth state token consumption against TOCTOU

### DIFF
--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalAuthService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalAuthService.cs
@@ -257,6 +257,8 @@ internal class ExternalAuthService(
         if (state is null)
         {
             // Distinguish expired from invalid/already-used for a better error message.
+            // Note: a used token that also happens to be expired will report "expired" rather
+            // than "invalid". This is acceptable since both cases deny the request.
             var isExpired = await dbContext.ExternalAuthStates
                 .AnyAsync(s => s.Token == hashedToken && s.ExpiresAt < utcNow, cancellationToken);
 


### PR DESCRIPTION
## Summary

- Move all state token validation (unused, not expired) into the WHERE clause so the database filters out already-consumed or expired tokens before loading
- Narrows the TOCTOU window: a concurrent request arriving after SaveChangesAsync won't find the row because IsUsed is already true in the DB
- Add follow-up AnyAsync check to distinguish expired tokens from invalid/already-used for better error messages
- Full atomicity (single UPDATE WHERE via ExecuteUpdateAsync) deferred to Testcontainers migration (#174) since InMemory provider doesn't support it

## Test plan

- [x] All existing ExternalAuthServiceTests pass (HandleCallback_UsedState_ReturnsError, HandleCallback_ExpiredState_ReturnsError, HandleCallback_ValidState_MarksAsUsed)
- [x] Full backend test suite green

Closes #375