### PR TITLE
refactor(auth): use HttpClient name constants in DI registration

### DIFF
--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Extensions/ServiceCollectionExtensions.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Extensions/ServiceCollectionExtensions.cs
@@ -163,7 +163,7 @@ public static class ServiceCollectionExtensions
 
             if (externalOptions.Google.Enabled)
             {
-                services.AddHttpClient("Google-OAuth");
+                services.AddHttpClient(GoogleAuthProvider.HttpClientName);
                 services.AddSingleton<IExternalAuthProvider>(sp =>
                     new GoogleAuthProvider(
                         sp.GetRequiredService<IHttpClientFactory>(),
@@ -173,7 +173,7 @@ public static class ServiceCollectionExtensions
 
             if (externalOptions.GitHub.Enabled)
             {
-                services.AddHttpClient("GitHub-OAuth");
+                services.AddHttpClient(GitHubAuthProvider.HttpClientName);
                 services.AddSingleton<IExternalAuthProvider>(sp =>
                     new GitHubAuthProvider(
                         sp.GetRequiredService<IHttpClientFactory>(),

--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/GitHubAuthProvider.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/GitHubAuthProvider.cs
@@ -21,7 +21,7 @@ internal sealed class GitHubAuthProvider(
     private const string TokenEndpoint = "https://github.com/login/oauth/access_token";
     private const string UserEndpoint = "https://api.github.com/user";
     private const string UserEmailsEndpoint = "https://api.github.com/user/emails";
-    private const string HttpClientName = "GitHub-OAuth";
+    internal const string HttpClientName = "GitHub-OAuth";
 
     /// <inheritdoc />
     public string Name => "GitHub";

--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/GoogleAuthProvider.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/GoogleAuthProvider.cs
@@ -19,7 +19,7 @@ internal sealed class GoogleAuthProvider(
     private const string AuthorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth";
     private const string TokenEndpoint = "https://oauth2.googleapis.com/token";
     private const string UserInfoEndpoint = "https://www.googleapis.com/oauth2/v3/userinfo";
-    private const string HttpClientName = "Google-OAuth";
+    internal const string HttpClientName = "Google-OAuth";
 
     /// <inheritdoc />
     public string Name => "Google";


### PR DESCRIPTION
## Summary

- Change `HttpClientName` from `private const` to `internal const` in `GoogleAuthProvider` and `GitHubAuthProvider`
- Reference these constants in `ServiceCollectionExtensions` instead of inline string literals
- A silent name mismatch between DI registration and provider class would cause a hard-to-debug runtime failure; using the same constant eliminates this risk
- ServiceDefaults already applies `AddStandardResilienceHandler` globally via `ConfigureHttpClientDefaults`, so per-client resilience handlers are unnecessary

Stacked on #385.

## Test plan

- [x] Full backend test suite green

Closes #381