### PR TITLE
feat(frontend): shared utility components + separator cleanup

### DIFF
--- a/src/frontend/src/lib/components/admin/AuditTrailCard.svelte
+++ b/src/frontend/src/lib/components/admin/AuditTrailCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { EmptyState } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Badge } from '$lib/components/ui/badge';
@@ -99,12 +100,7 @@
 				></div>
 			</div>
 		{:else if events.length === 0}
-			<div class="flex flex-col items-center justify-center py-12 text-center">
-				<div class="mb-3 rounded-full bg-muted p-3">
-					<History class="h-6 w-6 text-muted-foreground" />
-				</div>
-				<p class="text-sm text-muted-foreground">{m.audit_trail_empty()}</p>
-			</div>
+			<EmptyState icon={History} message={m.audit_trail_empty()} />
 		{:else}
 			<Timeline>
 				{#each events as event, i (event.id)}

--- a/src/frontend/src/lib/components/admin/JobExecutionHistory.svelte
+++ b/src/frontend/src/lib/components/admin/JobExecutionHistory.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { EmptyState } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { History } from '@lucide/svelte';
@@ -24,12 +25,7 @@
 	</Card.Header>
 	<Card.Content class="p-0">
 		{#if executions.length === 0}
-			<div class="flex flex-col items-center justify-center py-12 text-center">
-				<div class="mb-3 rounded-full bg-muted p-3">
-					<History class="h-6 w-6 text-muted-foreground" />
-				</div>
-				<p class="text-sm text-muted-foreground">{m.admin_jobDetail_noHistory()}</p>
-			</div>
+			<EmptyState icon={History} message={m.admin_jobDetail_noHistory()} />
 		{:else}
 			<!-- Mobile: card list -->
 			<div class="divide-y md:hidden">

--- a/src/frontend/src/lib/components/admin/JobTable.svelte
+++ b/src/frontend/src/lib/components/admin/JobTable.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { EmptyState } from '$lib/components/common';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Clock } from '@lucide/svelte';
 	import { resolve } from '$app/paths';
@@ -18,12 +19,7 @@
 </script>
 
 {#if jobs.length === 0}
-	<div class="flex flex-col items-center justify-center py-12 text-center">
-		<div class="mb-3 rounded-full bg-muted p-3">
-			<Clock class="h-6 w-6 text-muted-foreground" />
-		</div>
-		<p class="text-sm text-muted-foreground">{m.admin_jobs_noJobs()}</p>
-	</div>
+	<EmptyState icon={Clock} message={m.admin_jobs_noJobs()} />
 {:else}
 	<!-- Mobile: card list -->
 	<div class="divide-y md:hidden">

--- a/src/frontend/src/lib/components/admin/RoleCardGrid.svelte
+++ b/src/frontend/src/lib/components/admin/RoleCardGrid.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { EmptyState } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Shield, Users } from '@lucide/svelte';
@@ -31,12 +32,7 @@
 </script>
 
 {#if roles.length === 0}
-	<div class="flex flex-col items-center justify-center py-12 text-center">
-		<div class="mb-3 rounded-full bg-muted p-3">
-			<Shield class="h-6 w-6 text-muted-foreground" />
-		</div>
-		<p class="text-sm text-muted-foreground">{m.admin_roles_noResults()}</p>
-	</div>
+	<EmptyState icon={Shield} message={m.admin_roles_noResults()} />
 {:else}
 	<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
 		{#each roles as role (role.id)}

--- a/src/frontend/src/lib/components/admin/RoleDetailsCard.svelte
+++ b/src/frontend/src/lib/components/admin/RoleDetailsCard.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+	import { ReadOnlyNotice } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import { Lock, Loader2, Save } from '@lucide/svelte';
+	import { Loader2, Save } from '@lucide/svelte';
 	import { browserClient, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
 	import { invalidateAll } from '$app/navigation';
@@ -70,12 +71,7 @@
 	</Card.Header>
 	<Card.Content class="space-y-4">
 		{#if !canManageRoles}
-			<div
-				class="flex items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground"
-			>
-				<Lock class="h-4 w-4 shrink-0" />
-				<span>{m.common_readOnlyNotice()}</span>
-			</div>
+			<ReadOnlyNotice message={m.common_readOnlyNotice()} />
 		{/if}
 		<div>
 			<Label for="role-name">{m.admin_roles_name()}</Label>

--- a/src/frontend/src/lib/components/admin/RolePermissionsSection.svelte
+++ b/src/frontend/src/lib/components/admin/RolePermissionsSection.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+	import { ReadOnlyNotice } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import * as Alert from '$lib/components/ui/alert';
 	import { Button } from '$lib/components/ui/button';
 	import { RolePermissionEditor } from '$lib/components/admin';
-	import { Lock, Loader2, Save, TriangleAlert } from '@lucide/svelte';
+	import { Loader2, Save, TriangleAlert } from '@lucide/svelte';
 	import { browserClient, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
 	import { invalidateAll } from '$app/navigation';
@@ -64,12 +65,7 @@
 			</Alert.Root>
 		{/if}
 		{#if !canEditPermissions}
-			<div
-				class="flex items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground"
-			>
-				<Lock class="h-4 w-4 shrink-0" />
-				<span>{m.common_readOnlyNotice()}</span>
-			</div>
+			<ReadOnlyNotice message={m.common_readOnlyNotice()} />
 		{/if}
 		<RolePermissionEditor
 			{permissionGroups}

--- a/src/frontend/src/lib/components/admin/UserManagementCard.svelte
+++ b/src/frontend/src/lib/components/admin/UserManagementCard.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import { ReadOnlyNotice } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import * as Alert from '$lib/components/ui/alert';
 	import { RoleManagement, AccountActions } from '$lib/components/admin';
-	import { Lock, TriangleAlert } from '@lucide/svelte';
+	import { TriangleAlert } from '@lucide/svelte';
 	import type { AdminUser, AdminRole } from '$lib/types';
 	import type { Cooldown } from '$lib/state';
 	import * as m from '$lib/paraglide/messages';
@@ -41,12 +42,7 @@
 			</Alert.Root>
 		{/if}
 		{#if !canManage && !canAssignRoles}
-			<div
-				class="flex items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground"
-			>
-				<Lock class="h-4 w-4 shrink-0" />
-				<span>{m.admin_userDetail_cannotManage()}</span>
-			</div>
+			<ReadOnlyNotice message={m.admin_userDetail_cannotManage()} />
 		{/if}
 
 		<div class={!canManage && !canAssignRoles ? 'opacity-60' : ''}>

--- a/src/frontend/src/lib/components/admin/UserTable.svelte
+++ b/src/frontend/src/lib/components/admin/UserTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import { EmptyState } from '$lib/components/common';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { Users, ChevronRight, EyeOff } from '@lucide/svelte';
@@ -29,12 +30,7 @@
 
 <!-- eslint-disable svelte/no-navigation-without-resolve -- hrefs are pre-resolved using resolve() -->
 {#if users.length === 0}
-	<div class="flex flex-col items-center justify-center py-12 text-center">
-		<div class="mb-3 rounded-full bg-muted p-3">
-			<Users class="h-6 w-6 text-muted-foreground" />
-		</div>
-		<p class="text-sm text-muted-foreground">{m.admin_users_noResults()}</p>
-	</div>
+	<EmptyState icon={Users} message={m.admin_users_noResults()} />
 {:else}
 	<!-- Mobile: card list -->
 	<div class="divide-y md:hidden">

--- a/src/frontend/src/lib/components/common/EmptyState.svelte
+++ b/src/frontend/src/lib/components/common/EmptyState.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { Component } from 'svelte';
+	import type { IconProps } from '@lucide/svelte';
+
+	interface Props {
+		icon: Component<IconProps>;
+		message: string;
+	}
+
+	let { icon: Icon, message }: Props = $props();
+</script>
+
+<div class="flex flex-col items-center justify-center py-12 text-center">
+	<div class="mb-3 rounded-full bg-muted p-3">
+		<Icon class="h-6 w-6 text-muted-foreground" />
+	</div>
+	<p class="text-sm text-muted-foreground">{message}</p>
+</div>

--- a/src/frontend/src/lib/components/common/PageHeader.svelte
+++ b/src/frontend/src/lib/components/common/PageHeader.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { Separator } from '$lib/components/ui/separator';
+
+	interface Props {
+		title: string;
+		description?: string;
+		/** Optional actions rendered to the right of the title on larger screens */
+		actions?: Snippet;
+	}
+
+	let { title, description, actions }: Props = $props();
+</script>
+
+<div>
+	{#if actions}
+		<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+			<div>
+				<h3 class="text-lg font-medium">{title}</h3>
+				{#if description}
+					<p class="text-sm text-muted-foreground">{description}</p>
+				{/if}
+			</div>
+			{@render actions()}
+		</div>
+	{:else}
+		<h3 class="text-lg font-medium">{title}</h3>
+		{#if description}
+			<p class="text-sm text-muted-foreground">{description}</p>
+		{/if}
+	{/if}
+</div>
+<Separator />

--- a/src/frontend/src/lib/components/common/ReadOnlyNotice.svelte
+++ b/src/frontend/src/lib/components/common/ReadOnlyNotice.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { Lock } from '@lucide/svelte';
+
+	interface Props {
+		message: string;
+	}
+
+	let { message }: Props = $props();
+</script>
+
+<div class="flex items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground">
+	<Lock class="h-4 w-4 shrink-0" />
+	<span>{message}</span>
+</div>

--- a/src/frontend/src/lib/components/common/index.ts
+++ b/src/frontend/src/lib/components/common/index.ts
@@ -1,2 +1,5 @@
+export { default as EmptyState } from './EmptyState.svelte';
+export { default as PageHeader } from './PageHeader.svelte';
+export { default as ReadOnlyNotice } from './ReadOnlyNotice.svelte';
 export { default as StatusIndicator } from './StatusIndicator.svelte';
 export { default as WorkInProgress } from './WorkInProgress.svelte';

--- a/src/frontend/src/lib/components/layout/SidebarNav.svelte
+++ b/src/frontend/src/lib/components/layout/SidebarNav.svelte
@@ -3,6 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { cn, hasPermission, Permissions } from '$lib/utils';
 	import { buttonVariants } from '$lib/components/ui/button';
+	import { Separator } from '$lib/components/ui/separator';
 	import { LayoutDashboard, Users, Shield, Clock, KeyRound, type IconProps } from '@lucide/svelte';
 	import * as m from '$lib/paraglide/messages';
 	import * as Tooltip from '$lib/components/ui/tooltip';
@@ -125,7 +126,7 @@
 	{/each}
 
 	{#if visibleAdminItems.length > 0}
-		<div class="my-2 h-px w-full bg-border"></div>
+		<Separator class="my-2" />
 		{#if !collapsed}
 			<span class="mb-1 px-3 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
 				{m.nav_admin()}

--- a/src/frontend/src/lib/components/settings/ActivityLog.svelte
+++ b/src/frontend/src/lib/components/settings/ActivityLog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { EmptyState } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Timeline, TimelineItem, TimelineContent } from '$lib/components/ui/timeline';
@@ -71,12 +72,7 @@
 				></div>
 			</div>
 		{:else if events.length === 0}
-			<div class="flex flex-col items-center justify-center py-12 text-center">
-				<div class="mb-3 rounded-full bg-muted p-3">
-					<History class="h-6 w-6 text-muted-foreground" />
-				</div>
-				<p class="text-sm text-muted-foreground">{m.settings_activityLog_empty()}</p>
-			</div>
+			<EmptyState icon={History} message={m.settings_activityLog_empty()} />
 		{:else}
 			<Timeline>
 				{#each events as event, i (event.id)}

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { PageHeader } from '$lib/components/common';
 	import * as m from '$lib/paraglide/messages';
 </script>
 
@@ -8,9 +9,5 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div>
-		<h3 class="text-lg font-medium">{m.meta_dashboard_title()}</h3>
-		<p class="text-sm text-muted-foreground">{m.meta_dashboard_description()}</p>
-	</div>
-	<div class="h-px w-full bg-border"></div>
+	<PageHeader title={m.meta_dashboard_title()} description={m.meta_dashboard_description()} />
 </div>

--- a/src/frontend/src/routes/(app)/admin/jobs/+page.svelte
+++ b/src/frontend/src/routes/(app)/admin/jobs/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { PageHeader } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
@@ -43,46 +44,43 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div>
-			<h3 class="text-lg font-medium">{m.admin_jobs_title()}</h3>
-			<p class="text-sm text-muted-foreground">{m.admin_jobs_description()}</p>
-		</div>
-		{#if canManageJobs}
-			<Dialog.Root bind:open={restoreDialogOpen}>
-				<Dialog.Trigger>
-					{#snippet child({ props })}
-						<Button variant="outline" class="w-full sm:w-auto" {...props}>
-							<RefreshCw class="me-2 h-4 w-4" />
-							{m.admin_jobs_restore()}
-						</Button>
-					{/snippet}
-				</Dialog.Trigger>
-				<Dialog.Content>
-					<Dialog.Header>
-						<Dialog.Title>{m.admin_jobs_restore()}</Dialog.Title>
-						<Dialog.Description>{m.admin_jobs_restoreConfirm()}</Dialog.Description>
-					</Dialog.Header>
-					<Dialog.Footer class="flex-col-reverse sm:flex-row">
-						<Button variant="outline" onclick={() => (restoreDialogOpen = false)}>
-							{m.common_cancel()}
-						</Button>
-						<Button disabled={isRestoring || cooldown.active} onclick={restoreJobs}>
-							{#if cooldown.active}
-								{m.common_waitSeconds({ seconds: cooldown.remaining })}
-							{:else}
-								{#if isRestoring}
-									<Loader2 class="me-2 h-4 w-4 animate-spin" />
-								{/if}
+	<PageHeader title={m.admin_jobs_title()} description={m.admin_jobs_description()}>
+		{#snippet actions()}
+			{#if canManageJobs}
+				<Dialog.Root bind:open={restoreDialogOpen}>
+					<Dialog.Trigger>
+						{#snippet child({ props })}
+							<Button variant="outline" class="w-full sm:w-auto" {...props}>
+								<RefreshCw class="me-2 h-4 w-4" />
 								{m.admin_jobs_restore()}
-							{/if}
-						</Button>
-					</Dialog.Footer>
-				</Dialog.Content>
-			</Dialog.Root>
-		{/if}
-	</div>
-	<div class="h-px w-full bg-border"></div>
+							</Button>
+						{/snippet}
+					</Dialog.Trigger>
+					<Dialog.Content>
+						<Dialog.Header>
+							<Dialog.Title>{m.admin_jobs_restore()}</Dialog.Title>
+							<Dialog.Description>{m.admin_jobs_restoreConfirm()}</Dialog.Description>
+						</Dialog.Header>
+						<Dialog.Footer class="flex-col-reverse sm:flex-row">
+							<Button variant="outline" onclick={() => (restoreDialogOpen = false)}>
+								{m.common_cancel()}
+							</Button>
+							<Button disabled={isRestoring || cooldown.active} onclick={restoreJobs}>
+								{#if cooldown.active}
+									{m.common_waitSeconds({ seconds: cooldown.remaining })}
+								{:else}
+									{#if isRestoring}
+										<Loader2 class="me-2 h-4 w-4 animate-spin" />
+									{/if}
+									{m.admin_jobs_restore()}
+								{/if}
+							</Button>
+						</Dialog.Footer>
+					</Dialog.Content>
+				</Dialog.Root>
+			{/if}
+		{/snippet}
+	</PageHeader>
 
 	<Card.Root>
 		<Card.Content class="p-0">

--- a/src/frontend/src/routes/(app)/admin/jobs/[jobId]/+page.svelte
+++ b/src/frontend/src/routes/(app)/admin/jobs/[jobId]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { buttonVariants } from '$lib/components/ui/button';
+	import { Separator } from '$lib/components/ui/separator';
 	import { JobInfoCard, JobActionsCard, JobExecutionHistory } from '$lib/components/admin';
 	import { ArrowLeft } from '@lucide/svelte';
 	import { hasPermission, Permissions, cn } from '$lib/utils';
@@ -32,7 +33,7 @@
 			<p class="font-mono text-sm text-muted-foreground">{data.job?.cron}</p>
 		</div>
 	</div>
-	<div class="h-px w-full bg-border"></div>
+	<Separator />
 
 	{#if data.job}
 		<div class="grid gap-6 lg:grid-cols-2">

--- a/src/frontend/src/routes/(app)/admin/oauth-providers/+page.svelte
+++ b/src/frontend/src/routes/(app)/admin/oauth-providers/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { PageHeader } from '$lib/components/common';
 	import { OAuthProviderCard } from '$lib/components/admin';
 	import { hasPermission, Permissions } from '$lib/utils';
 	import * as m from '$lib/paraglide/messages';
@@ -15,11 +16,10 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div>
-		<h3 class="text-lg font-medium">{m.admin_oauthProviders_title()}</h3>
-		<p class="text-sm text-muted-foreground">{m.admin_oauthProviders_description()}</p>
-	</div>
-	<div class="h-px w-full bg-border"></div>
+	<PageHeader
+		title={m.admin_oauthProviders_title()}
+		description={m.admin_oauthProviders_description()}
+	/>
 
 	{#if data.providers.length === 0}
 		<p class="text-sm text-muted-foreground">{m.admin_oauthProviders_noProviders()}</p>

--- a/src/frontend/src/routes/(app)/admin/roles/+page.svelte
+++ b/src/frontend/src/routes/(app)/admin/roles/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { PageHeader } from '$lib/components/common';
 	import { Button } from '$lib/components/ui/button';
 	import { RoleCardGrid, CreateRoleDialog } from '$lib/components/admin';
 	import { hasPermission, Permissions } from '$lib/utils';
@@ -18,19 +19,16 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-		<div>
-			<h3 class="text-lg font-medium">{m.admin_roles_title()}</h3>
-			<p class="text-sm text-muted-foreground">{m.admin_roles_description()}</p>
-		</div>
-		{#if canManageRoles}
-			<Button size="sm" onclick={() => (createDialogOpen = true)}>
-				<Plus class="me-1 h-4 w-4" />
-				{m.admin_roles_createRole()}
-			</Button>
-		{/if}
-	</div>
-	<div class="h-px w-full bg-border"></div>
+	<PageHeader title={m.admin_roles_title()} description={m.admin_roles_description()}>
+		{#snippet actions()}
+			{#if canManageRoles}
+				<Button onclick={() => (createDialogOpen = true)}>
+					<Plus class="me-1 h-4 w-4" />
+					{m.admin_roles_createRole()}
+				</Button>
+			{/if}
+		{/snippet}
+	</PageHeader>
 
 	<RoleCardGrid roles={data.roles} />
 </div>

--- a/src/frontend/src/routes/(app)/admin/roles/[id]/+page.svelte
+++ b/src/frontend/src/routes/(app)/admin/roles/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Badge } from '$lib/components/ui/badge';
+	import { Separator } from '$lib/components/ui/separator';
 	import {
 		RoleDetailsCard,
 		RolePermissionsSection,
@@ -51,7 +52,7 @@
 			{m.admin_roles_userCountLabel({ count: data.role?.userCount ?? 0 })}
 		</span>
 	</div>
-	<div class="h-px w-full bg-border"></div>
+	<Separator />
 
 	<RoleDetailsCard
 		roleId={data.role?.id ?? ''}

--- a/src/frontend/src/routes/(app)/admin/users/+page.svelte
+++ b/src/frontend/src/routes/(app)/admin/users/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
+	import { PageHeader } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import { Input } from '$lib/components/ui/input';
 	import { Button } from '$lib/components/ui/button';
@@ -54,11 +55,7 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div>
-		<h3 class="text-lg font-medium">{m.admin_users_title()}</h3>
-		<p class="text-sm text-muted-foreground">{m.admin_users_description()}</p>
-	</div>
-	<div class="h-px w-full bg-border"></div>
+	<PageHeader title={m.admin_users_title()} description={m.admin_users_description()} />
 
 	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 		<div class="relative max-w-sm flex-1">

--- a/src/frontend/src/routes/(app)/admin/users/[id]/+page.svelte
+++ b/src/frontend/src/routes/(app)/admin/users/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { buttonVariants } from '$lib/components/ui/button';
+	import { Separator } from '$lib/components/ui/separator';
 	import { UserDetailCards, AuditTrailCard } from '$lib/components/admin';
 	import { ArrowLeft, EyeOff } from '@lucide/svelte';
 	import { hasPermission, Permissions, cn } from '$lib/utils';
@@ -45,7 +46,7 @@
 			{/if}
 		</div>
 	</div>
-	<div class="h-px w-full bg-border"></div>
+	<Separator />
 
 	{#if data.adminUser && data.user}
 		<UserDetailCards

--- a/src/frontend/src/routes/(app)/profile/+page.svelte
+++ b/src/frontend/src/routes/(app)/profile/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { PageHeader } from '$lib/components/common';
 	import { ProfileForm, AccountDetails } from '$lib/components/profile';
 	import type { PageData } from './$types';
 	import * as m from '$lib/paraglide/messages';
@@ -12,11 +13,7 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div>
-		<h3 class="text-lg font-medium">{m.profile_title()}</h3>
-		<p class="text-sm text-muted-foreground">{m.profile_description()}</p>
-	</div>
-	<div class="h-px w-full bg-border"></div>
+	<PageHeader title={m.profile_title()} description={m.profile_description()} />
 	<div class="grid gap-6 lg:grid-cols-2">
 		<ProfileForm user={data.user} />
 		<AccountDetails user={data.user} />

--- a/src/frontend/src/routes/(app)/settings/+page.svelte
+++ b/src/frontend/src/routes/(app)/settings/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { PageHeader } from '$lib/components/common';
 	import {
 		ChangePasswordForm,
 		SetPasswordForm,
@@ -26,11 +27,7 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<div>
-		<h3 class="text-lg font-medium">{m.settings_title()}</h3>
-		<p class="text-sm text-muted-foreground">{m.settings_description()}</p>
-	</div>
-	<div class="h-px w-full bg-border"></div>
+	<PageHeader title={m.settings_title()} description={m.settings_description()} />
 	<div class="space-y-8">
 		{#if hasPassword}
 			<ChangePasswordForm />


### PR DESCRIPTION
## Summary

- Add `PageHeader`, `EmptyState`, and `ReadOnlyNotice` shared components to `$lib/components/common/`
- Replace all 11 raw separator divs (`h-px w-full bg-border`) with shadcn `<Separator />`
- Extract repeated empty state pattern (icon + message) from 6 components into `EmptyState`
- Extract read-only lock notice from 3 components into `ReadOnlyNotice`
- Remove dead `Lock` icon imports from components now using `ReadOnlyNotice`

Part 1 of #407 (shadcn-first design overhaul). Foundation for PRs 2-6.

## Test plan

- [ ] All pages render correctly (dashboard, profile, settings, admin users/roles/jobs/oauth)
- [ ] Separators render identically to the previous raw divs
- [ ] Empty states display when data is absent (empty user list, empty job list, etc.)
- [ ] Read-only notices appear when user lacks permissions
- [ ] Mobile, tablet, desktop layouts unaffected
- [ ] No overflow or scrollbar regressions