### PR TITLE
feat(frontend): add FieldError, shadcn Slider, and final polish

### DIFF
--- a/src/frontend/src/lib/components/admin/CreateRoleDialog.svelte
+++ b/src/frontend/src/lib/components/admin/CreateRoleDialog.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import { Loader2 } from '@lucide/svelte';
 	import { browserClient, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
@@ -78,11 +79,7 @@
 						aria-invalid={!!fieldErrors.name}
 						aria-describedby={fieldErrors.name ? 'role-name-error' : undefined}
 					/>
-					{#if fieldErrors.name}
-						<p id="role-name-error" class="mt-1 text-xs text-destructive">
-							{fieldErrors.name}
-						</p>
-					{/if}
+					<FieldError id="role-name-error" message={fieldErrors.name} class="mt-1" />
 				</div>
 				<div>
 					<Label for="role-description">{m.admin_roles_descriptionLabel()}</Label>
@@ -95,11 +92,7 @@
 						aria-invalid={!!fieldErrors.description}
 						aria-describedby={fieldErrors.description ? 'role-description-error' : undefined}
 					/>
-					{#if fieldErrors.description}
-						<p id="role-description-error" class="mt-1 text-xs text-destructive">
-							{fieldErrors.description}
-						</p>
-					{/if}
+					<FieldError id="role-description-error" message={fieldErrors.description} class="mt-1" />
 				</div>
 			</div>
 			<Dialog.Footer class="flex-col-reverse sm:flex-row">

--- a/src/frontend/src/lib/components/admin/CreateUserDialog.svelte
+++ b/src/frontend/src/lib/components/admin/CreateUserDialog.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import { Loader2 } from '@lucide/svelte';
 	import { browserClient, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
@@ -85,11 +86,7 @@
 						aria-invalid={!!fieldErrors.email}
 						aria-describedby={fieldErrors.email ? 'user-email-error' : undefined}
 					/>
-					{#if fieldErrors.email}
-						<p id="user-email-error" class="mt-1 text-xs text-destructive">
-							{fieldErrors.email}
-						</p>
-					{/if}
+					<FieldError id="user-email-error" message={fieldErrors.email} class="mt-1" />
 				</div>
 				<div>
 					<Label for="user-firstName">{m.admin_users_inviteFirstName()}</Label>
@@ -102,11 +99,7 @@
 						aria-invalid={!!fieldErrors.firstName}
 						aria-describedby={fieldErrors.firstName ? 'user-firstName-error' : undefined}
 					/>
-					{#if fieldErrors.firstName}
-						<p id="user-firstName-error" class="mt-1 text-xs text-destructive">
-							{fieldErrors.firstName}
-						</p>
-					{/if}
+					<FieldError id="user-firstName-error" message={fieldErrors.firstName} class="mt-1" />
 				</div>
 				<div>
 					<Label for="user-lastName">{m.admin_users_inviteLastName()}</Label>
@@ -119,11 +112,7 @@
 						aria-invalid={!!fieldErrors.lastName}
 						aria-describedby={fieldErrors.lastName ? 'user-lastName-error' : undefined}
 					/>
-					{#if fieldErrors.lastName}
-						<p id="user-lastName-error" class="mt-1 text-xs text-destructive">
-							{fieldErrors.lastName}
-						</p>
-					{/if}
+					<FieldError id="user-lastName-error" message={fieldErrors.lastName} class="mt-1" />
 				</div>
 			</div>
 			<Dialog.Footer class="flex-col-reverse sm:flex-row">

--- a/src/frontend/src/lib/components/admin/OAuthProviderCard.svelte
+++ b/src/frontend/src/lib/components/admin/OAuthProviderCard.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import { Switch } from '$lib/components/ui/switch';
 	import { ProviderIcon } from '$lib/components/oauth';
 	import { browserClient, handleMutationError } from '$lib/api';
@@ -122,11 +123,7 @@
 				aria-invalid={!!fieldErrors.clientId}
 				aria-describedby={fieldErrors.clientId ? `${provider.provider}-client-id-error` : undefined}
 			/>
-			{#if fieldErrors.clientId}
-				<p id="{provider.provider}-client-id-error" class="text-xs text-destructive">
-					{fieldErrors.clientId}
-				</p>
-			{/if}
+			<FieldError id="{provider.provider}-client-id-error" message={fieldErrors.clientId} />
 		</div>
 		<div class="space-y-2">
 			<Label for="{provider.provider}-client-secret">
@@ -146,11 +143,7 @@
 					? `${provider.provider}-client-secret-error`
 					: undefined}
 			/>
-			{#if fieldErrors.clientSecret}
-				<p id="{provider.provider}-client-secret-error" class="text-xs text-destructive">
-					{fieldErrors.clientSecret}
-				</p>
-			{/if}
+			<FieldError id="{provider.provider}-client-secret-error" message={fieldErrors.clientSecret} />
 		</div>
 	</Card.Content>
 	{#if canManage}

--- a/src/frontend/src/lib/components/admin/RoleDetailsCard.svelte
+++ b/src/frontend/src/lib/components/admin/RoleDetailsCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ReadOnlyNotice } from '$lib/components/common';
+	import { FieldError, ReadOnlyNotice } from '$lib/components/common';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
@@ -84,9 +84,8 @@
 				aria-invalid={!!fieldErrors.name}
 				aria-describedby={fieldErrors.name ? 'role-name-error' : undefined}
 			/>
-			{#if fieldErrors.name}
-				<p id="role-name-error" class="mt-1 text-xs text-destructive">{fieldErrors.name}</p>
-			{:else if isSystem}
+			<FieldError id="role-name-error" message={fieldErrors.name} class="mt-1" />
+			{#if isSystem}
 				<p class="mt-1 text-xs text-muted-foreground">{m.admin_roles_systemNameReadonly()}</p>
 			{/if}
 		</div>
@@ -102,11 +101,7 @@
 				aria-invalid={!!fieldErrors.description}
 				aria-describedby={fieldErrors.description ? 'role-desc-error' : undefined}
 			/>
-			{#if fieldErrors.description}
-				<p id="role-desc-error" class="mt-1 text-xs text-destructive">
-					{fieldErrors.description}
-				</p>
-			{/if}
+			<FieldError id="role-desc-error" message={fieldErrors.description} class="mt-1" />
 		</div>
 		{#if canManageRoles}
 			<div class="flex flex-col gap-2 sm:flex-row sm:justify-end">

--- a/src/frontend/src/lib/components/auth/RegisterDialog.svelte
+++ b/src/frontend/src/lib/components/auth/RegisterDialog.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import { PhoneInput } from '$lib/components/ui/phone-input';
 	import { browserClient, getErrorMessage, handleMutationError } from '$lib/api';
 	import * as m from '$lib/paraglide/messages';
@@ -182,9 +183,7 @@
 						class={fieldShakes.class('firstName')}
 						aria-invalid={!!fieldErrors.firstName}
 					/>
-					{#if fieldErrors.firstName}
-						<p class="text-xs text-destructive">{fieldErrors.firstName}</p>
-					{/if}
+					<FieldError message={fieldErrors.firstName} />
 				</div>
 				<div class="grid gap-2">
 					<Label for="lastName">{m.auth_register_lastName()}</Label>
@@ -196,9 +195,7 @@
 						class={fieldShakes.class('lastName')}
 						aria-invalid={!!fieldErrors.lastName}
 					/>
-					{#if fieldErrors.lastName}
-						<p class="text-xs text-destructive">{fieldErrors.lastName}</p>
-					{/if}
+					<FieldError message={fieldErrors.lastName} />
 				</div>
 			</div>
 			<div class="grid gap-2">
@@ -213,9 +210,7 @@
 					class={fieldShakes.class('email')}
 					aria-invalid={!!fieldErrors.email}
 				/>
-				{#if fieldErrors.email}
-					<p class="text-xs text-destructive">{fieldErrors.email}</p>
-				{/if}
+				<FieldError message={fieldErrors.email} />
 			</div>
 			<div class="grid gap-2">
 				<Label for="phone">{m.auth_register_phone()}</Label>
@@ -226,9 +221,7 @@
 					class={fieldShakes.class('phoneNumber')}
 					aria-invalid={!!fieldErrors.phoneNumber}
 				/>
-				{#if fieldErrors.phoneNumber}
-					<p class="text-xs text-destructive">{fieldErrors.phoneNumber}</p>
-				{/if}
+				<FieldError message={fieldErrors.phoneNumber} />
 			</div>
 			<div class="grid gap-2">
 				<Label for="password">{m.auth_register_password()}</Label>
@@ -243,9 +236,7 @@
 					class={fieldShakes.class('password')}
 					aria-invalid={!!fieldErrors.password}
 				/>
-				{#if fieldErrors.password}
-					<p class="text-xs text-destructive">{fieldErrors.password}</p>
-				{/if}
+				<FieldError message={fieldErrors.password} />
 			</div>
 			<div class="grid gap-2">
 				<Label for="confirmPassword">{m.auth_register_confirmPassword()}</Label>
@@ -260,9 +251,7 @@
 					class={fieldShakes.class('confirmPassword')}
 					aria-invalid={!!fieldErrors.confirmPassword}
 				/>
-				{#if fieldErrors.confirmPassword}
-					<p class="text-xs text-destructive">{fieldErrors.confirmPassword}</p>
-				{/if}
+				<FieldError message={fieldErrors.confirmPassword} />
 			</div>
 			<TurnstileWidget
 				siteKey={turnstileSiteKey}

--- a/src/frontend/src/lib/components/auth/ResetPasswordForm.svelte
+++ b/src/frontend/src/lib/components/auth/ResetPasswordForm.svelte
@@ -6,6 +6,7 @@
 	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { FieldError } from '$lib/components/common';
 	import { Label } from '$lib/components/ui/label';
 	import * as Card from '$lib/components/ui/card';
 	import { ThemeToggle, LanguageSelector } from '$lib/components/layout';
@@ -223,11 +224,7 @@
 								aria-invalid={!!fieldErrors.newPassword}
 								aria-describedby={fieldErrors.newPassword ? 'newPassword-error' : undefined}
 							/>
-							{#if fieldErrors.newPassword}
-								<p id="newPassword-error" class="text-xs text-destructive">
-									{fieldErrors.newPassword}
-								</p>
-							{/if}
+							<FieldError id="newPassword-error" message={fieldErrors.newPassword} />
 						</div>
 
 						<div class="grid gap-2">
@@ -242,11 +239,7 @@
 								aria-invalid={!!fieldErrors.confirmPassword}
 								aria-describedby={fieldErrors.confirmPassword ? 'confirmPassword-error' : undefined}
 							/>
-							{#if fieldErrors.confirmPassword}
-								<p id="confirmPassword-error" class="text-xs text-destructive">
-									{fieldErrors.confirmPassword}
-								</p>
-							{/if}
+							<FieldError id="confirmPassword-error" message={fieldErrors.confirmPassword} />
 						</div>
 
 						<Button type="submit" class="w-full" disabled={isLoading || cooldown.active}>

--- a/src/frontend/src/lib/components/common/FieldError.svelte
+++ b/src/frontend/src/lib/components/common/FieldError.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	interface Props {
+		id?: string;
+		message?: string;
+		class?: string;
+	}
+
+	let { id, message, class: className }: Props = $props();
+</script>
+
+{#if message}
+	<p {id} class="text-xs text-destructive {className ?? ''}">{message}</p>
+{/if}

--- a/src/frontend/src/lib/components/common/index.ts
+++ b/src/frontend/src/lib/components/common/index.ts
@@ -1,5 +1,6 @@
 export { default as AdminBreadcrumb } from './AdminBreadcrumb.svelte';
 export { default as EmptyState } from './EmptyState.svelte';
+export { default as FieldError } from './FieldError.svelte';
 export { default as LoadingSpinner } from './LoadingSpinner.svelte';
 export { default as PageHeader } from './PageHeader.svelte';
 export { default as ReadOnlyNotice } from './ReadOnlyNotice.svelte';

--- a/src/frontend/src/lib/components/profile/AvatarCropStep.svelte
+++ b/src/frontend/src/lib/components/profile/AvatarCropStep.svelte
@@ -3,6 +3,7 @@
 	import type { CropArea } from 'svelte-easy-crop';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
+	import { Slider } from '$lib/components/ui/slider';
 	import * as m from '$lib/paraglide/messages';
 
 	interface Props {
@@ -54,17 +55,17 @@
 
 	<!-- Zoom slider -->
 	<div class="flex items-center gap-3 px-2">
-		<label for="zoom-slider" class="text-sm whitespace-nowrap text-muted-foreground">
+		<span class="text-sm whitespace-nowrap text-muted-foreground">
 			{m.profile_avatar_zoom()}
-		</label>
-		<input
-			id="zoom-slider"
-			type="range"
-			min="1"
-			max="3"
-			step="0.01"
-			bind:value={zoom}
-			class="h-2 w-full cursor-pointer appearance-none rounded-lg bg-muted accent-primary"
+		</span>
+		<Slider
+			type="single"
+			min={1}
+			max={3}
+			step={0.01}
+			value={zoom}
+			onValueChange={(v) => (zoom = v)}
+			aria-label={m.profile_avatar_zoom()}
 		/>
 	</div>
 </div>

--- a/src/frontend/src/lib/components/profile/AvatarSelectStep.svelte
+++ b/src/frontend/src/lib/components/profile/AvatarSelectStep.svelte
@@ -2,6 +2,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Avatar from '$lib/components/ui/avatar';
 	import { Button } from '$lib/components/ui/button';
+	import { FieldError } from '$lib/components/common';
 	import * as m from '$lib/paraglide/messages';
 	import { Upload } from '@lucide/svelte';
 
@@ -106,9 +107,7 @@
 		onchange={handleInputChange}
 	/>
 
-	{#if fileError}
-		<p class="text-xs text-destructive">{fileError}</p>
-	{/if}
+	<FieldError message={fileError} />
 </div>
 <Dialog.Footer class="flex-col gap-2 sm:flex-row sm:justify-between">
 	<div>

--- a/src/frontend/src/lib/components/profile/ProfileForm.svelte
+++ b/src/frontend/src/lib/components/profile/ProfileForm.svelte
@@ -5,6 +5,7 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Label } from '$lib/components/ui/label';
 	import { PhoneInput } from '$lib/components/ui/phone-input';
+	import { FieldError } from '$lib/components/common';
 	import { ProfileHeader } from '$lib/components/profile';
 	import type { User } from '$lib/types';
 	import * as m from '$lib/paraglide/messages';
@@ -115,9 +116,7 @@
 							aria-invalid={!!fieldErrors.firstName}
 							aria-describedby={fieldErrors.firstName ? 'firstName-error' : undefined}
 						/>
-						{#if fieldErrors.firstName}
-							<p id="firstName-error" class="text-xs text-destructive">{fieldErrors.firstName}</p>
-						{/if}
+						<FieldError id="firstName-error" message={fieldErrors.firstName} />
 					</div>
 					<div class="grid gap-2">
 						<Label for="lastName">{m.profile_personalInfo_lastName()}</Label>
@@ -130,9 +129,7 @@
 							aria-invalid={!!fieldErrors.lastName}
 							aria-describedby={fieldErrors.lastName ? 'lastName-error' : undefined}
 						/>
-						{#if fieldErrors.lastName}
-							<p id="lastName-error" class="text-xs text-destructive">{fieldErrors.lastName}</p>
-						{/if}
+						<FieldError id="lastName-error" message={fieldErrors.lastName} />
 					</div>
 				</div>
 
@@ -146,9 +143,7 @@
 						aria-invalid={!!fieldErrors.phoneNumber}
 						aria-describedby={fieldErrors.phoneNumber ? 'phoneNumber-error' : undefined}
 					/>
-					{#if fieldErrors.phoneNumber}
-						<p id="phoneNumber-error" class="text-xs text-destructive">{fieldErrors.phoneNumber}</p>
-					{/if}
+					<FieldError id="phoneNumber-error" message={fieldErrors.phoneNumber} />
 				</div>
 
 				<div class="grid gap-2">
@@ -161,9 +156,7 @@
 						aria-invalid={!!fieldErrors.bio}
 						aria-describedby={fieldErrors.bio ? 'bio-error' : undefined}
 					/>
-					{#if fieldErrors.bio}
-						<p id="bio-error" class="text-xs text-destructive">{fieldErrors.bio}</p>
-					{/if}
+					<FieldError id="bio-error" message={fieldErrors.bio} />
 				</div>
 
 				<div class="flex flex-col gap-2 sm:flex-row sm:justify-end">

--- a/src/frontend/src/lib/components/settings/ChangePasswordForm.svelte
+++ b/src/frontend/src/lib/components/settings/ChangePasswordForm.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import * as m from '$lib/paraglide/messages';
 	import { browserClient, getErrorMessage, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
@@ -91,11 +92,7 @@
 						aria-invalid={!!fieldErrors.currentPassword}
 						aria-describedby={fieldErrors.currentPassword ? 'currentPassword-error' : undefined}
 					/>
-					{#if fieldErrors.currentPassword}
-						<p id="currentPassword-error" class="text-xs text-destructive">
-							{fieldErrors.currentPassword}
-						</p>
-					{/if}
+					<FieldError id="currentPassword-error" message={fieldErrors.currentPassword} />
 				</div>
 
 				<div class="grid gap-2">
@@ -111,11 +108,7 @@
 						aria-invalid={!!fieldErrors.newPassword}
 						aria-describedby={fieldErrors.newPassword ? 'newPassword-error' : undefined}
 					/>
-					{#if fieldErrors.newPassword}
-						<p id="newPassword-error" class="text-xs text-destructive">
-							{fieldErrors.newPassword}
-						</p>
-					{/if}
+					<FieldError id="newPassword-error" message={fieldErrors.newPassword} />
 				</div>
 
 				<div class="grid gap-2">
@@ -130,11 +123,7 @@
 						aria-invalid={!!fieldErrors.confirmPassword}
 						aria-describedby={fieldErrors.confirmPassword ? 'confirmPassword-error' : undefined}
 					/>
-					{#if fieldErrors.confirmPassword}
-						<p id="confirmPassword-error" class="text-xs text-destructive">
-							{fieldErrors.confirmPassword}
-						</p>
-					{/if}
+					<FieldError id="confirmPassword-error" message={fieldErrors.confirmPassword} />
 				</div>
 
 				<div class="flex flex-col gap-2 sm:flex-row sm:justify-end">

--- a/src/frontend/src/lib/components/settings/DeleteAccountDialog.svelte
+++ b/src/frontend/src/lib/components/settings/DeleteAccountDialog.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import * as m from '$lib/paraglide/messages';
 	import { browserClient, getErrorMessage, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
@@ -98,15 +99,10 @@
 						class={fieldShakes.class('password')}
 						disabled={isLoading}
 					/>
-					{#if fieldErrors.password}
-						<p id="deleteAccountPasswordError" class="text-xs text-destructive">
-							{fieldErrors.password}
-						</p>
-					{:else if generalError}
-						<p id="deleteAccountPasswordError" class="text-xs text-destructive">
-							{generalError}
-						</p>
-					{/if}
+					<FieldError
+						id="deleteAccountPasswordError"
+						message={fieldErrors.password || generalError}
+					/>
 				</div>
 			</div>
 			<Dialog.Footer class="flex-col-reverse gap-2 sm:flex-row">

--- a/src/frontend/src/lib/components/settings/SetPasswordForm.svelte
+++ b/src/frontend/src/lib/components/settings/SetPasswordForm.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import * as m from '$lib/paraglide/messages';
 	import { browserClient, getErrorMessage, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
@@ -88,11 +89,7 @@
 						aria-invalid={!!fieldErrors.newPassword}
 						aria-describedby={fieldErrors.newPassword ? 'newPassword-error' : undefined}
 					/>
-					{#if fieldErrors.newPassword}
-						<p id="newPassword-error" class="text-xs text-destructive">
-							{fieldErrors.newPassword}
-						</p>
-					{/if}
+					<FieldError id="newPassword-error" message={fieldErrors.newPassword} />
 				</div>
 
 				<div class="grid gap-2">
@@ -107,11 +104,7 @@
 						aria-invalid={!!fieldErrors.confirmPassword}
 						aria-describedby={fieldErrors.confirmPassword ? 'confirmPassword-error' : undefined}
 					/>
-					{#if fieldErrors.confirmPassword}
-						<p id="confirmPassword-error" class="text-xs text-destructive">
-							{fieldErrors.confirmPassword}
-						</p>
-					{/if}
+					<FieldError id="confirmPassword-error" message={fieldErrors.confirmPassword} />
 				</div>
 
 				<div class="flex flex-col gap-2 sm:flex-row sm:justify-end">

--- a/src/frontend/src/lib/components/settings/TwoFactorDisableDialog.svelte
+++ b/src/frontend/src/lib/components/settings/TwoFactorDisableDialog.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import * as m from '$lib/paraglide/messages';
 	import { browserClient, getErrorMessage, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
@@ -97,15 +98,10 @@
 						class={fieldShakes.class('password')}
 						disabled={isLoading}
 					/>
-					{#if fieldErrors.password}
-						<p id="disableTwoFactorPasswordError" class="text-xs text-destructive">
-							{fieldErrors.password}
-						</p>
-					{:else if generalError}
-						<p id="disableTwoFactorPasswordError" class="text-xs text-destructive">
-							{generalError}
-						</p>
-					{/if}
+					<FieldError
+						id="disableTwoFactorPasswordError"
+						message={fieldErrors.password || generalError}
+					/>
 				</div>
 			</div>
 			<Dialog.Footer class="flex-col-reverse gap-2 sm:flex-row">

--- a/src/frontend/src/lib/components/settings/TwoFactorRecoveryCodesDialog.svelte
+++ b/src/frontend/src/lib/components/settings/TwoFactorRecoveryCodesDialog.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { FieldError } from '$lib/components/common';
 	import * as m from '$lib/paraglide/messages';
 	import { browserClient, getErrorMessage, handleMutationError } from '$lib/api';
 	import { toast } from '$lib/components/ui/sonner';
@@ -126,15 +127,10 @@
 							class={fieldShakes.class('password')}
 							disabled={isLoading}
 						/>
-						{#if fieldErrors.password}
-							<p id="regenerateCodesPasswordError" class="text-xs text-destructive">
-								{fieldErrors.password}
-							</p>
-						{:else if generalError}
-							<p id="regenerateCodesPasswordError" class="text-xs text-destructive">
-								{generalError}
-							</p>
-						{/if}
+						<FieldError
+							id="regenerateCodesPasswordError"
+							message={fieldErrors.password || generalError}
+						/>
 					</div>
 				</div>
 				<Dialog.Footer class="flex-col-reverse gap-2 sm:flex-row">

--- a/src/frontend/src/lib/components/ui/slider/index.ts
+++ b/src/frontend/src/lib/components/ui/slider/index.ts
@@ -1,0 +1,7 @@
+import Root from './slider.svelte';
+
+export {
+	Root,
+	//
+	Root as Slider
+};

--- a/src/frontend/src/lib/components/ui/slider/slider.svelte
+++ b/src/frontend/src/lib/components/ui/slider/slider.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { Slider as SliderPrimitive } from 'bits-ui';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		orientation = 'horizontal',
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SliderPrimitive.RootProps> = $props();
+</script>
+
+<!--
+Discriminated Unions + Destructing (required for bindable) do not
+get along, so we shut typescript up by casting `value` to `never`.
+-->
+<SliderPrimitive.Root
+	bind:ref
+	bind:value={value as never}
+	data-slot="slider"
+	{orientation}
+	class={cn(
+		'relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col',
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ thumbs })}
+		<span
+			data-orientation={orientation}
+			data-slot="slider-track"
+			class={cn(
+				'relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5'
+			)}
+		>
+			<SliderPrimitive.Range
+				data-slot="slider-range"
+				class={cn(
+					'absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full'
+				)}
+			/>
+		</span>
+		{#each thumbs as thumb (thumb)}
+			<SliderPrimitive.Thumb
+				data-slot="slider-thumb"
+				index={thumb}
+				class="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+			/>
+		{/each}
+	{/snippet}
+</SliderPrimitive.Root>


### PR DESCRIPTION
## Summary
- Add FieldError shared component replacing ~30 raw `<p class="text-xs text-destructive">` instances
- Replace raw `<input type="range">` in AvatarCropStep with shadcn Slider
- Dead code cleanup across all components

Replaces auto-closed PR #411.

## Test plan
- [ ] Form validation errors display correctly with FieldError
- [ ] Avatar crop slider works on mobile and desktop
- [ ] All forms validate and submit correctly