### PR TITLE
fix(frontend): stack user count and invite button on mobile

### DIFF
--- a/src/frontend/src/routes/(app)/admin/users/+page.svelte
+++ b/src/frontend/src/routes/(app)/admin/users/+page.svelte
@@ -71,7 +71,7 @@
 				}}
 			/>
 		</div>
-		<div class="flex items-center justify-between gap-3 sm:justify-end">
+		<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
 			{#if data.users?.totalCount != null}
 				<p class="text-sm text-muted-foreground">
 					{m.admin_users_totalUsers({ count: data.users.totalCount })}


### PR DESCRIPTION
## Summary
- The total users count and Invite User button were competing for horizontal space on mobile, causing text to wrap awkwardly
- Changed from always-horizontal flex row to `flex-col` on mobile, `sm:flex-row` on desktop

## Test plan
- [ ] Open Admin > Users on mobile viewport - count text should appear above the full-width Invite User button
- [ ] On `sm+` viewports, count and button should remain side-by-side aligned to the end

Generated with [Claude Code](https://claude.com/claude-code)