### PR TITLE
docs: update documentation for OAuth, 2FA, command palette, and Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # NETrock
 
-**Full-stack .NET 10 + SvelteKit foundation. Auth, permissions, background jobs, admin panel - wired up so you can skip the boilerplate.**
+**Full-stack .NET 10 + SvelteKit foundation for building real products.**
 
-Clean Architecture. 1000+ tests. Dockerized. API-first - use the included frontend or bring your own.
+OAuth with 8 providers. TOTP two-factor auth. Admin-configurable everything. 1000+ tests. API-first - use the included frontend or bring your own.
 
 [![CI](https://github.com/fpindej/netrock/actions/workflows/ci.yml/badge.svg)](https://github.com/fpindej/netrock/actions/workflows/ci.yml)
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)](https://dotnet.microsoft.com/)
@@ -25,7 +25,9 @@ Clean Architecture. 1000+ tests. Dockerized. API-first - use the included fronte
 
 Every project starts the same way: authentication, role management, rate limiting, validation, API documentation, Docker setup... You spend weeks on infrastructure before writing a single line of business logic.
 
-**NETrock skips all of that.** It ships a .NET 10 API with a SvelteKit frontend - auth that actually works, documented conventions, and the kind of infrastructure you'd build anyway. Login works. Token rotation works. The permission system enforces role hierarchy. The admin panel manages users, roles, and background jobs. The Docker stack spins up with health checks. CI runs your tests.
+**NETrock skips all of that.** It ships a production-grade .NET 10 API with a SvelteKit frontend that goes far beyond boilerplate. Users can log in with Google, GitHub, Discord, Apple, Microsoft, Facebook, LinkedIn, or X - configured by admins from the UI, no redeploy needed. Two-factor authentication with TOTP and recovery codes is built in. The permission system enforces role hierarchy. The admin panel manages users, roles, background jobs, and OAuth providers with AES-256-GCM encrypted credentials. Full audit trail, PII compliance, and rate limiting are part of the foundation.
+
+**For developers**, every convention is documented, the architecture is tested at the layer boundary, and Claude Code skills automate common workflows. **For end users**, the product they interact with has dark mode, i18n, a command palette, responsive design, and security features they expect from a real application.
 
 **Fork it, init it, own it.** After initialization, there is no dependency on "the template." It's your code, your architecture, your product. Every decision is documented so you can understand it, change it, or throw it away.
 
@@ -33,13 +35,13 @@ Every project starts the same way: authentication, role management, rate limitin
 
 ## What You Get
 
-**Backend** - JWT auth with token rotation and reuse detection, TOTP two-factor authentication, permission-based authorization with role hierarchy, transactional email delivery (MailKit), rate limiting, HybridCache with stampede protection, PostgreSQL with soft delete and audit trails, S3-compatible file storage (MinIO locally, any S3 provider in production), Hangfire background jobs, OpenAPI docs, health checks, Result pattern with ProblemDetails everywhere. [See full details ->](docs/features.md#backend--net-10--c-13)
+**Backend** - JWT auth with token rotation and reuse detection, TOTP two-factor authentication with recovery codes, OAuth/OIDC external login with 8 providers (admin-configurable from the UI), permission-based authorization with role hierarchy, transactional email with Fluid templates, rate limiting, HybridCache, PostgreSQL with soft delete and audit trails, S3-compatible file storage, Hangfire background jobs, OpenAPI docs, health checks, Result pattern with ProblemDetails. [See full details ->](docs/features.md#backend--net-10--c-13)
 
-**Frontend** - Svelte 5 runes, type-safe API client generated from OpenAPI, automatic token refresh, Tailwind CSS 4 with shadcn-svelte, BFF proxy with CSRF protection, i18n, security headers, permission guards, dark mode, admin panel with user/role/job management. [See full details ->](docs/features.md#frontend--sveltekit--svelte-5)
+**Frontend** - Svelte 5 runes, type-safe API client from OpenAPI, Tailwind CSS 4 with shadcn-svelte component library, Cmd+K command palette with permission-gated navigation, BFF proxy with CSRF protection, i18n (English + Czech, add more with a single JSON file), dark mode, responsive design with 44px touch targets, admin panel with user/role/job/OAuth provider management. [See full details ->](docs/features.md#frontend--sveltekit--svelte-5)
 
-**Infrastructure** - Aspire AppHost for local development (one command, full OTEL dashboard, MailPit for local email testing), structured logs, metrics, and traces via OpenTelemetry, Docker Compose for production deployment, init script for project bootstrapping, build script with multi-registry support, GitHub Actions CI with smart path filtering, Dependabot. [See full details ->](docs/features.md#infrastructure--devops)
+**Infrastructure** - Aspire AppHost for local development (one command for the full stack with OTEL dashboard and MailPit for email testing), Docker Compose for production, init script for project bootstrapping, build script with multi-registry support, GitHub Actions CI with smart path filtering, Claude Code skills for development workflows. [See full details ->](docs/features.md#infrastructure--devops)
 
-**Security** - Security-first design with HttpOnly JWT cookies, refresh token rotation with reuse detection, TOTP two-factor authentication with challenge tokens and recovery codes, security stamp propagation, CSP with nonces, CORS startup guard, rate limiting, and input validation everywhere. [See full details ->](docs/security.md)
+**Security** - HttpOnly JWT cookies, refresh token rotation with reuse detection, TOTP 2FA with challenge tokens and recovery codes, OAuth state tokens with TOCTOU protection, AES-256-GCM encrypted provider credentials, PII compliance with server-side masking, security stamp propagation, CSP with nonces, rate limiting, input validation everywhere. [See full details ->](docs/security.md)
 
 ---
 
@@ -98,7 +100,27 @@ Three test users are seeded (configured in `appsettings.Development.json`):
 
 ### 3. Start Building
 
-Add your domain entities, services, and pages - the architecture guides you. Use `/` skills (`.claude/skills/`) for step-by-step procedures.
+Add your domain entities, services, and pages - the architecture guides you.
+
+---
+
+## Claude Code Integration
+
+NETrock ships with 20 native [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills that automate common development workflows. Type `/` in Claude Code to see all available skills.
+
+| Skill | What it does |
+|---|---|
+| `/new-feature` | Scaffold a full-stack feature - entity, service, controller, frontend page |
+| `/new-endpoint` | Add an API endpoint to an existing feature |
+| `/new-entity` | Create a domain entity with EF Core configuration |
+| `/new-page` | Create a frontend page with routing, i18n, and navigation |
+| `/gen-types` | Regenerate frontend TypeScript types from the OpenAPI spec |
+| `/create-pr` | Create a PR with session docs, reviews, and labels |
+| `/review-pr` | Review a PR for production-readiness |
+| `/review-design` | Review frontend components for UI/UX standards |
+| `/create-issue` | Create a GitHub issue with labels |
+
+The project also includes `CLAUDE.md`, `AGENTS.md`, and `FILEMAP.md` - structured context files that give Claude Code deep understanding of the architecture, conventions, and change impact across the codebase. No separate onboarding needed - Claude Code reads the project and follows the rules.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,22 +4,24 @@
 
 ```
 Frontend (SvelteKit :5173)
-    │
-    │  /api/* proxy (catch-all server route)
-    │  Forwards cookies + headers, validates CSRF origin
-    ▼
+    |
+    |  /api/* proxy (catch-all server route)
+    |  Forwards cookies + headers, validates CSRF origin
+    v
 Backend API (.NET :8080)
-    │
-    │  Clean Architecture
-    │  WebApi → Application ← Infrastructure → Domain (+Shared)
-    │
-    ├── PostgreSQL           — EF Core, soft delete, audit trails, Hangfire storage
-    ├── MinIO                — S3-compatible blob storage (avatars, file uploads)
-    ├── Hangfire             — Recurring + fire-and-forget background jobs
-    └── OpenTelemetry ──────→ Aspire Dashboard (local) / OTLP endpoint (production)
+    |
+    |  Clean Architecture
+    |  WebApi -> Application <- Infrastructure -> Domain (+Shared)
+    |
+    |-- PostgreSQL           - EF Core, soft delete, audit trails, Hangfire storage
+    |-- MinIO                - S3-compatible blob storage (avatars, file uploads)
+    |-- Hangfire             - Recurring + fire-and-forget background jobs
+    |-- OAuth Providers      - Google, GitHub, Discord, Apple, Microsoft, Facebook, LinkedIn, X
+    |-- SMTP (MailKit)       - Transactional email with Fluid templates
+    +-- OpenTelemetry -------> Aspire Dashboard (local) / OTLP endpoint (production)
 ```
 
-The backend follows Clean Architecture with **architecture tests** that enforce dependency direction at build time — Domain and Shared have zero dependencies, Application only references Domain and Shared, Infrastructure never references WebApi. Breaking these rules fails the build.
+The backend follows Clean Architecture with **architecture tests** that enforce dependency direction at build time - Domain and Shared have zero dependencies, Application only references Domain and Shared, Infrastructure never references WebApi. Breaking these rules fails the build.
 
 ---
 
@@ -30,11 +32,11 @@ NETrock is thoroughly tested across 4 test projects, covering every layer of the
 | Project | What it covers |
 |---|---|
 | **Unit Tests** | Result pattern, error messages, phone normalization, base entity, roles, permissions |
-| **Component Tests** | Auth service (login, register, refresh, token rotation), admin service (hierarchy, role assignment, lock/delete), role management, user service |
-| **API Tests** | Full HTTP pipeline (status codes, auth gates, ProblemDetails shape), all validators, response contract testing, permission enforcement, rate limiting |
+| **Component Tests** | Auth service (login, register, refresh, token rotation, 2FA), admin service (hierarchy, role assignment, lock/delete), role management, user service, OAuth external auth |
+| **API Tests** | Full HTTP pipeline (status codes, auth gates, ProblemDetails shape), all validators, response contract testing, permission enforcement, rate limiting, 2FA endpoints, OAuth endpoints |
 | **Architecture Tests** | Layer dependency direction, naming conventions, access modifiers |
 
-All tests run in-process — no Docker or PostgreSQL required:
+All tests run in-process - no Docker or PostgreSQL required:
 
 ```bash
 dotnet test src/backend/MyProject.slnx -c Release
@@ -46,37 +48,39 @@ dotnet test src/backend/MyProject.slnx -c Release
 
 ```
 src/
-├── backend/                          # .NET 10 API (Clean Architecture)
-│   ├── YourProject.Shared/           # Result pattern, error types, cross-cutting utilities
-│   ├── YourProject.Domain/           # Entities with audit fields and soft delete
-│   ├── YourProject.Application/      # Interfaces, DTOs, service contracts, permissions
-│   ├── YourProject.Infrastructure/   # EF Core, Identity, HybridCache, Hangfire, S3 storage, email, implementations
-│   ├── YourProject.WebApi/           # Controllers, middleware, validation, authorization
-│   └── tests/
-│       ├── YourProject.Unit.Tests/        # Pure logic tests (Result, entities, roles, permissions)
-│       ├── YourProject.Component.Tests/   # Service tests with mocked dependencies
-│       ├── YourProject.Api.Tests/         # HTTP integration tests + validator tests
-│       └── YourProject.Architecture.Tests/ # Dependency direction + naming enforcement
-│
-└── frontend/                         # SvelteKit frontend
-    └── src/
-        ├── lib/
-        │   ├── api/                  # Type-safe API client + generated OpenAPI types
-        │   ├── components/           # Feature-organized with barrel exports
-        │   │   ├── admin/            # Admin components (tables, cards, editors)
-        │   │   ├── auth/             # Login, register, CAPTCHA, password reset
-        │   │   ├── layout/           # Sidebar, header, theme, language, shortcuts
-        │   │   ├── profile/          # Profile editing, avatar management
-        │   │   ├── settings/         # Password change, account deletion
-        │   │   └── ui/               # shadcn-svelte (button, card, dialog, input, ...)
-        │   ├── state/                # Reactive state (.svelte.ts) — theme, cooldown, shake, sidebar, shortcuts
-        │   └── utils/                # Permissions, platform detection, class merging
-        ├── routes/
-        │   ├── (app)/                # Authenticated pages with sidebar layout
-        │   │   ├── admin/            # User management, role management, job dashboard
-        │   │   ├── profile/          # User profile
-        │   │   └── settings/         # Account settings
-        │   ├── (public)/             # Login, forgot/reset password, email verification
-        │   └── api/                  # CSRF-protected API proxy to backend
-        └── messages/                 # i18n translations (en, cs)
+|-- backend/                          # .NET 10 API (Clean Architecture)
+|   |-- YourProject.Shared/           # Result pattern, error types, cross-cutting utilities
+|   |-- YourProject.Domain/           # Entities with audit fields and soft delete
+|   |-- YourProject.Application/      # Interfaces, DTOs, service contracts, permissions
+|   |-- YourProject.Infrastructure/   # EF Core, Identity, HybridCache, Hangfire, S3, email, OAuth
+|   |-- YourProject.WebApi/           # Controllers, middleware, validation, authorization
+|   +-- tests/
+|       |-- YourProject.Unit.Tests/        # Pure logic tests (Result, entities, roles, permissions)
+|       |-- YourProject.Component.Tests/   # Service tests with mocked dependencies
+|       |-- YourProject.Api.Tests/         # HTTP integration tests + validator tests
+|       +-- YourProject.Architecture.Tests/ # Dependency direction + naming enforcement
+|
++-- frontend/                         # SvelteKit frontend
+    +-- src/
+        |-- lib/
+        |   |-- api/                  # Type-safe API client + generated OpenAPI types
+        |   |-- components/           # Feature-organized with barrel exports
+        |   |   |-- admin/            # Admin components (tables, cards, editors, OAuth management)
+        |   |   |-- auth/             # Login, register, CAPTCHA, 2FA, password reset
+        |   |   |-- common/           # Shared components (PageHeader, EmptyState, FieldError)
+        |   |   |-- layout/           # Sidebar, header, breadcrumbs, command palette, theme, language
+        |   |   |-- oauth/            # OAuth provider buttons, connected accounts, provider icons
+        |   |   |-- profile/          # Profile editing, avatar management
+        |   |   |-- settings/         # Password change, 2FA setup, account deletion
+        |   |   +-- ui/               # shadcn-svelte (button, card, dialog, table, command, sidebar, ...)
+        |   |-- state/                # Reactive state (.svelte.ts) - theme, shortcuts, health, breadcrumb
+        |   +-- utils/                # Permissions, platform detection, audit labels, class merging
+        |-- routes/
+        |   |-- (app)/                # Authenticated pages with sidebar layout
+        |   |   |-- admin/            # User, role, job, and OAuth provider management
+        |   |   |-- profile/          # User profile
+        |   |   +-- settings/         # Account settings, 2FA, connected accounts
+        |   |-- (public)/             # Login, register, forgot/reset password, email verification, OAuth callback
+        |   +-- api/                  # CSRF-protected API proxy to backend
+        +-- messages/                 # i18n translations (en, cs)
 ```

--- a/docs/before-you-ship.md
+++ b/docs/before-you-ship.md
@@ -16,6 +16,8 @@ NETrock works out of the box for local development, but there are things you nee
 - [ ] **Frontend URL in emails** - set `Email__FrontendBaseUrl` to your production domain so email verification and password reset links work
 - [ ] **Bootstrap admin** - uncomment and fill in `Seed__Users__*` entries in `deploy/envs/production/seed.env` to create an initial SuperAdmin on first deploy. Idempotent - safe to leave set, but remove after creating admin accounts through the UI
 - [ ] **File storage** - configure `FileStorage__*` env vars for your S3-compatible provider. Local dev uses MinIO (included in Aspire). For production, point to your preferred provider - AWS S3, Cloudflare R2, DigitalOcean Spaces, Backblaze B2, or any S3-compatible service. Set `FileStorage__Endpoint`, `FileStorage__AccessKey`, `FileStorage__SecretKey`, `FileStorage__BucketName`, `FileStorage__Region` (if applicable), and `FileStorage__UseSSL=true`. Use `/manage-file-storage` skill for provider-specific configs or to remove file storage entirely
+- [ ] **OAuth encryption key** - set `Authentication__OAuth__EncryptionKey` to a cryptographically random base64 string (32+ bytes). This key encrypts OAuth provider client secrets at rest with AES-256-GCM. Generate with `openssl rand -base64 32`. Without this, OAuth provider management will not work in production
+- [ ] **OAuth providers** - configure OAuth providers from the admin UI after first deploy. Each provider needs a client ID and secret from the provider's developer console (Google Cloud Console, GitHub Developer Settings, etc.). Admins can enable/disable providers, test connections, and update credentials without redeploying
 
 ## Should Do
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,13 +4,13 @@
 
 ## Local Development (Aspire)
 
-Aspire is the sole local development workflow. It starts all infrastructure (PostgreSQL, MinIO) as containers and launches the API and frontend dev server.
+Aspire is the sole local development workflow. It starts all infrastructure (PostgreSQL, MinIO, MailPit) as containers and launches the API and frontend dev server.
 
 ```bash
 dotnet run --project src/backend/MyProject.AppHost
 ```
 
-The Aspire Dashboard URL appears in the console. All service URLs (API docs, pgAdmin, MinIO) are linked from the Dashboard.
+The Aspire Dashboard URL appears in the console. All service URLs (API docs, pgAdmin, MinIO, MailPit) are linked from the Dashboard.
 
 ### Debugging with breakpoints in Rider/VS
 
@@ -18,7 +18,32 @@ Launch the AppHost project from your IDE. The API runs in-process with full debu
 
 ### Configuration
 
-Behavioral config (log levels, rate limits, JWT lifetimes, CORS, seed users) lives in `appsettings.Development.json`. Infrastructure connection strings are injected by Aspire via environment variables — no manual config needed.
+Behavioral config (log levels, rate limits, JWT lifetimes, CORS, seed users, OAuth providers) lives in `appsettings.Development.json`. Infrastructure connection strings are injected by Aspire via environment variables - no manual config needed.
+
+### Email Testing
+
+MailPit captures all outgoing emails locally. Access the MailPit web UI from the Aspire Dashboard (port `BASE_PORT + 8`). Email verification, password reset, invitation, and 2FA disable notification emails all appear there immediately.
+
+---
+
+## Claude Code Skills
+
+NETrock ships with 20 native Claude Code skills that automate common development tasks. Type `/` in Claude Code to see all available skills.
+
+Key skills for daily development:
+
+| Skill | When to use |
+|---|---|
+| `/new-feature` | Adding a new full-stack feature (entity through to frontend page) |
+| `/new-endpoint` | Adding an API endpoint to an existing feature |
+| `/new-entity` | Creating a new backend entity with EF Core config |
+| `/new-page` | Creating a new frontend page with routing and i18n |
+| `/gen-types` | After changing backend DTOs or endpoints |
+| `/create-pr` | When your work is ready for review |
+| `/review-pr` | Reviewing someone else's PR |
+| `/review-design` | Checking UI/UX quality of frontend components |
+
+The project context files (`CLAUDE.md`, `AGENTS.md`, `FILEMAP.md`, backend/frontend `AGENTS.md`) provide Claude Code with deep understanding of the architecture and conventions. No separate onboarding needed.
 
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,60 +2,81 @@
 
 > Back to [README](../README.md)
 
-## Backend — .NET 10 / C# 13
+## Backend - .NET 10 / C# 13
 
 | Feature | Implementation |
 |---|---|
-| **Clean Architecture** | Domain → Application → Infrastructure → WebApi, with [architecture tests](../src/backend/tests/MyProject.Architecture.Tests) enforcing dependency rules |
-| **Authentication** | JWT in HttpOnly cookies, refresh token rotation with reuse detection, security stamp validation, remember-me persistent sessions |
-| **Authorization** | Permission-based with custom roles — atomic permissions (`users.view`, `roles.manage`, …) assigned per role, enforced via `[RequirePermission]` attribute |
-| **Role Hierarchy** | SuperAdmin > Admin > User — privilege escalation prevention, self-protection rules, system role guards |
+| **Clean Architecture** | Domain, Application, Infrastructure, WebApi - with [architecture tests](../src/backend/tests/MyProject.Architecture.Tests) enforcing dependency rules at build time |
+| **Authentication** | JWT in HttpOnly cookies, refresh token rotation with reuse detection (stolen token revokes entire family), security stamp validation, remember-me persistent sessions |
+| **Two-Factor Authentication** | TOTP-based 2FA with QR code setup, 6-digit verification, 8 single-use recovery codes, challenge token flow (login returns challenge, client submits TOTP code), admin can disable 2FA for locked-out users with automatic session revocation and notification email |
+| **OAuth / External Login** | OAuth 2.0 / OIDC external authentication with 8 providers out of the box - Google, GitHub, Discord, Apple, Microsoft, Facebook, LinkedIn, and X (Twitter). Manual `HttpClient`-based code exchange (no ASP.NET middleware). Auto-links accounts by verified email. 2FA is bypassed for OAuth logins (provider already verified identity). Provider credentials stored with AES-256-GCM encryption |
+| **OAuth Admin Management** | Admins configure OAuth providers entirely from the UI - enable/disable providers, set client ID and secret, configure scopes and endpoints, test connection with a single click. No redeploy required. Credentials encrypted at rest with AES-256-GCM |
+| **Authorization** | Permission-based with custom roles - atomic permissions (`users.view`, `roles.manage`, ...) assigned per role, enforced via `[RequirePermission]` attribute. SuperAdmin has implicit full access |
+| **Role Hierarchy** | SuperAdmin > Admin > User - privilege escalation prevention, self-protection rules, system role guards. Custom roles with arbitrary permission sets |
 | **Rate Limiting** | Global + per-endpoint policies (registration, auth, sensitive operations, admin mutations), configurable fixed-window with IP and user partitioning |
 | **Validation** | FluentValidation + Data Annotations, flowing constraints into OpenAPI spec and generated TypeScript types |
 | **Caching** | HybridCache (in-process L1) with auto-invalidation via EF Core interceptor, stampede protection, key management |
 | **Database** | PostgreSQL + EF Core with soft delete, full audit trail (created/updated/deleted by + at), global query filters |
+| **Audit Trail** | Append-only audit events table with JSONB metadata, 25+ action constants covering auth, account, admin, role, and OAuth operations. Admin per-user view and user self-activity log |
 | **API Documentation** | OpenAPI spec + Scalar UI, with custom transformers for enums, nullable types, numeric schemas, and camelCase query params |
-| **Error Handling** | Result pattern for business logic, `ProblemDetails` ([RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)) everywhere, structured error messages |
-| **Logging** | Serilog → OpenTelemetry with structured request logging, correlation, and Aspire Dashboard |
-| **Account Management** | Registration with CAPTCHA, login/logout, remember me, email verification, password reset, profile updates, account deletion |
-| **Admin Panel API** | User CRUD with search and pagination, custom role management with permission editor, role assignment with hierarchy enforcement |
-| **Background Jobs** | Hangfire with PostgreSQL persistence — recurring jobs via `IRecurringJobDefinition`, fire-and-forget, admin UI with trigger/pause/resume/restore, persistent pause state |
-| **Email** | Pluggable email service (NoOp for dev — swap in your SMTP/SendGrid/etc.), Fluid (Liquid) template engine with base layout, templated emails for verification, password reset, admin-initiated reset, and invitation |
-| **File Storage** | S3-compatible blob storage via generic `IFileStorageService` — MinIO locally, any S3 provider in production (AWS S3, Cloudflare R2, DigitalOcean Spaces, Backblaze B2). Avatar upload with SkiaSharp image processing (resize, WebP compression) |
-| **Health Checks** | `/health` (all), `/health/ready` (DB + S3), `/health/live` (liveness) — Docker healthcheck integration |
-| **Search** | User lookup with search and pagination in admin panel, PostgreSQL trigram similarity function pre-registered for custom use |
-| **Testing** | 4 test projects — unit, component (mocked services), API integration (WebApplicationFactory), architecture enforcement |
+| **Error Handling** | Result pattern for business logic, `ProblemDetails` ([RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)) on every error response, structured error messages |
+| **Logging** | Serilog bridged to OpenTelemetry with structured request logging, correlation, and Aspire Dashboard |
+| **Account Management** | Registration with CAPTCHA, login/logout, remember me, email verification, password reset, profile updates with avatar upload, account deletion, connected OAuth accounts management, set password for OAuth-only users |
+| **Admin Panel API** | User CRUD with search/pagination, custom role management with permission editor, role assignment with hierarchy enforcement, background job management, OAuth provider configuration, 2FA management |
+| **Background Jobs** | Hangfire with PostgreSQL persistence - recurring jobs via `IRecurringJobDefinition`, fire-and-forget, admin dashboard with trigger/pause/resume/restore, persistent pause state |
+| **Email** | MailKit SMTP with configurable enable/disable toggle, Fluid (Liquid) template engine with shared HTML base layout. Templates for verification, password reset, admin-initiated reset, invitation, and 2FA disable notification. MailPit integration for local email testing via Aspire |
+| **File Storage** | S3-compatible blob storage via `IFileStorageService` - MinIO locally, any S3 provider in production (AWS S3, Cloudflare R2, DigitalOcean Spaces, Backblaze B2). Avatar upload with SkiaSharp image processing (resize to 512x512, WebP compression) |
+| **PII Compliance** | `users.view_pii` permission gates personal data visibility. Emails masked to `j***@g***.com`, phone numbers to `***`. Self-view exemption. No PII in logs, URLs, or error responses |
+| **Health Checks** | `/health` (all), `/health/ready` (DB + S3), `/health/live` (liveness) - Docker healthcheck integration |
+| **Search** | User lookup with search and pagination, PostgreSQL trigram similarity function pre-registered for custom use |
+| **Testing** | 4 test projects - unit, component (mocked services), API integration (WebApplicationFactory), architecture enforcement. 1000+ tests covering auth flows, 2FA, OAuth, permissions, rate limiting, and response contracts |
 
-## Frontend — SvelteKit / Svelte 5
+## Frontend - SvelteKit / Svelte 5
 
 | Feature | Implementation |
 |---|---|
-| **Svelte 5 Runes** | Modern reactivity with `$state`, `$derived`, `$effect` — no legacy stores or `export let` |
-| **Type-Safe API Client** | Generated from OpenAPI spec via `openapi-typescript` — backend changes break the build, not the user |
-| **Automatic Token Refresh** | 401 → refresh → retry, transparent to components, thundering-herd protection |
-| **Tailwind CSS 4** | Utility-first styling with shadcn-svelte (bits-ui) headless components, CSS variable theming |
+| **Svelte 5 Runes** | Modern reactivity with `$state`, `$derived`, `$effect` - no legacy stores or `export let` |
+| **Type-Safe API Client** | Generated from OpenAPI spec via `openapi-typescript` - backend changes break the build, not the user |
+| **shadcn-svelte UI** | Full component library built on bits-ui headless primitives - Button, Card, Dialog, Table, Sidebar, Command, Breadcrumb, InputOTP, Tooltip, and more. CSS variable theming with Tailwind CSS 4 |
+| **Command Palette** | Cmd+K (Mac) / Ctrl+K (Windows/Linux) command palette for quick navigation. Permission-gated - users only see pages they can access. Keyboard shortcut help dialog (Shift+?) |
+| **OAuth Login** | "Sign in with" buttons for all configured providers, automatic redirect flow, connected accounts management in user settings, provider-specific icons |
+| **Two-Factor Authentication UI** | QR code TOTP setup wizard, shadcn InputOTP with auto-submit, recovery codes display with copy-to-clipboard, disable confirmation dialog |
+| **Automatic Token Refresh** | 401 interceptor with refresh and retry, transparent to components, thundering-herd protection |
 | **BFF Architecture** | Server-side API proxy handles cookies, CSRF validation, header filtering, and `X-Forwarded-For` propagation |
-| **i18n** | Paraglide JS — type-safe keys, compile-time validation, SSR-compatible, auto-detection via Accept-Language |
+| **i18n** | Paraglide JS - type-safe keys, compile-time validation, SSR-compatible, auto-detection via Accept-Language. Ships with English and Czech |
 | **Security Headers** | CSP with nonce mode, HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy on every response |
 | **Permission Guards** | Layout-level + page-level route guards, per-permission nav item filtering, component-level conditional rendering |
-| **Dark Mode** | Light/dark/system theme with localStorage persistence, FOUC prevention, and CSS variable theming |
-| **Responsive Design** | Mobile-first with sidebar drawer, breakpoint-aware layouts, logical CSS properties (RTL-ready) |
-| **Keyboard Shortcuts** | Global shortcuts (Cmd/Ctrl combos), platform-aware display, help dialog |
-| **Error Handling** | Unified mutation error handler — rate limiting with cooldown timers, field-level validation with shake animations, generic errors with toast |
-| **Admin UI** | User table with search/pagination, role card grid, permission checkbox editor, job dashboard with execution history |
-| **Avatar Upload** | Drag-and-drop file upload with client-side validation, preview, SkiaSharp server-side compression to WebP, S3 storage |
-| **Login UX** | API health indicator, form draft persistence (registration), animated success transition, CAPTCHA integration |
+| **Dark Mode** | Light/dark/system theme with localStorage persistence, FOUC prevention, CSS variable theming |
+| **Responsive Design** | Mobile-first with sidebar drawer, desktop content header with breadcrumbs, 44px touch targets on all interactive elements, logical CSS properties for RTL readiness, safe-area insets for notched devices |
+| **Loading States** | Skeleton components and loading spinners for async content throughout the admin panel |
+| **Error Handling** | Unified mutation error handler - rate limiting with visible cooldown timers, field-level validation with shake animations, generic errors with toast notifications |
+| **Admin UI** | User table with search/pagination and PII masking, role card grid with permission editor, job dashboard with execution history, OAuth provider management with toggle switches and test connection, 2FA management |
+| **Avatar Upload** | Drag-and-drop with client-side crop tool, preview, SkiaSharp server-side compression to WebP, S3 storage |
+| **Auth Pages** | Login with API health indicator, registration with form draft persistence, forgot/reset password flows, email verification - all with CAPTCHA integration and smooth transitions |
 
 ## Infrastructure & DevOps
 
 | Feature | Implementation |
 |---|---|
-| **Aspire Local Dev** | One `dotnet run` for the full stack — API, frontend (hot-reload), PostgreSQL, MinIO (S3 storage), OpenTelemetry Dashboard |
-| **Production Docker** | Docker Compose with production overlay — hardened containers, resource limits, network segmentation |
-| **Init Script** | Interactive project bootstrapping — renames solution, configures ports, creates migration, launches Aspire |
+| **Aspire Local Dev** | One `dotnet run` for the full stack - API, frontend (hot-reload), PostgreSQL, MinIO (S3 storage), MailPit (email testing), OpenTelemetry Dashboard with traces, logs, and metrics |
+| **Production Docker** | Docker Compose with base + production overlay - hardened containers (cap_drop, read_only, no-new-privileges), resource limits, two-tier network segmentation |
+| **Init Script** | Interactive project bootstrapping - renames solution, configures ports, creates migration, launches Aspire. Works on macOS, Linux, and Windows |
 | **Deploy Script** | Multi-registry support (Docker Hub, GHCR, ACR, ECR, DigitalOcean), semantic versioning, platform selection |
-| **CI Pipeline** | GitHub Actions with smart path filtering — backend-only PRs skip frontend checks and vice versa |
+| **CI Pipeline** | GitHub Actions with smart path filtering - backend-only PRs skip frontend checks and vice versa. Coverage reports with ReportGenerator |
 | **Docker Validation** | CI validates image builds on Dockerfile/dependency changes, with layer caching |
 | **Dependabot** | Weekly NuGet, npm, and GitHub Actions updates with grouped minor+patch PRs |
 | **Environment Config** | `.env` overrides for everything, documented precedence, working dev defaults out of the box |
-| **Production Hardening** | Dev config stripping from production builds, reverse proxy trust configuration, CORS production safeguard |
+| **Production Hardening** | Dev config stripping from production images, reverse proxy trust configuration, CORS production safeguard |
+| **Claude Code Skills** | 20 native skills for development workflows - feature scaffolding, endpoint creation, PR management, design review, type generation. Project-aware context files (`CLAUDE.md`, `AGENTS.md`, `FILEMAP.md`) for deep codebase understanding |
+
+## What Your Users Get
+
+NETrock is not just a developer tool - the included frontend delivers features that end users of your product interact with directly:
+
+- **Sign in with their existing accounts** - Google, GitHub, Discord, Apple, Microsoft, Facebook, LinkedIn, X. Admins enable providers from the UI without any redeploy
+- **Two-factor authentication** - TOTP setup with QR code, recovery codes for account recovery. Admins can disable 2FA for locked-out users
+- **Profile management** - Avatar upload with image cropping, profile editing, connected OAuth accounts management, password management
+- **Dark mode and language switching** - Light/dark/system theme, language auto-detection with manual override
+- **Keyboard-driven navigation** - Cmd+K command palette, global keyboard shortcuts, help dialog
+- **Mobile-ready** - Responsive design with touch-friendly targets, safe-area support for notched devices, sidebar drawer on mobile
+- **Security they can trust** - CAPTCHA on registration, visible rate limiting feedback, email verification, password reset flows

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-# Security — Not an Afterthought
+# Security - Not an Afterthought
 
 > Back to [README](../README.md)
 
@@ -6,38 +6,64 @@ NETrock is built **security-first**. Every decision defaults to the most restric
 
 ## Authentication & Session Security
 
-- **JWT in HttpOnly cookies** — tokens never touch JavaScript, immune to XSS theft
-- **Refresh token rotation** — single-use tokens with automatic family revocation on reuse detection (stolen token → all sessions invalidated)
-- **Security stamp validation** — permission changes propagate to active sessions via SHA-256 hashed stamps in JWT claims, cached in-process for performance
-- **Soft refresh** — role/permission changes invalidate access tokens but preserve refresh tokens, so users silently re-authenticate instead of getting force-logged-out
-- **Remember me** — persistent refresh tokens with configurable expiry, non-persistent sessions cleared on browser close
+- **JWT in HttpOnly cookies** - tokens never touch JavaScript, immune to XSS theft
+- **Refresh token rotation** - single-use tokens with automatic family revocation on reuse detection (stolen token revokes all sessions for that user)
+- **Security stamp validation** - permission changes propagate to active sessions via SHA-256 hashed stamps in JWT claims, cached in-process for performance
+- **Soft refresh** - role/permission changes invalidate access tokens but preserve refresh tokens, so users silently re-authenticate instead of getting force-logged-out
+- **Remember me** - persistent refresh tokens with configurable expiry (default 7 days), non-persistent sessions (default 24 hours) cleared on browser close
+
+## Two-Factor Authentication
+
+- **TOTP-based** - standard RFC 6238 time-based one-time passwords, compatible with any authenticator app (Google Authenticator, Authy, 1Password, etc.)
+- **Challenge token flow** - login returns a short-lived challenge token instead of full auth; client must submit valid TOTP code to complete authentication
+- **Recovery codes** - 8 single-use recovery codes generated during setup, each usable exactly once for account recovery if the authenticator is lost
+- **Admin disable** - admins with `users.manage_2fa` permission can disable 2FA for locked-out users, with automatic session revocation and notification email to the user
+- **OAuth bypass** - OAuth logins skip 2FA verification since the identity provider has already authenticated the user
+
+## OAuth / External Login Security
+
+- **Manual code exchange** - NETrock implements the OAuth 2.0 authorization code flow directly via `HttpClient`, not ASP.NET middleware. This gives full control over token exchange, error handling, and user linking
+- **State token CSRF protection** - every OAuth flow starts with a cryptographic state token stored in the database. The callback validates the token and immediately marks it as consumed to prevent replay
+- **TOCTOU hardening** - state token consumption uses `UPDATE ... WHERE consumed = false` with row-count verification to prevent time-of-check/time-of-use race conditions
+- **AES-256-GCM encrypted credentials** - OAuth provider client secrets are encrypted at rest using AES-256-GCM with a configurable encryption key. Credentials are only decrypted in-memory during the OAuth flow
+- **Auto-link by verified email** - when a user signs in with an OAuth provider, the system links the external account to an existing local account if the email matches and is verified. No duplicate accounts
+- **Test connection** - admins can validate OAuth provider credentials without a real user login. The test sends a dummy authorization code to the token endpoint and verifies the provider responds with the expected error (invalid grant) rather than a credentials error
+- **Per-provider configuration** - each provider is independently configurable (client ID, secret, scopes, endpoints) and can be enabled/disabled from the admin UI without a redeploy
 
 ## Authorization & Access Control
 
-- **Permission-based authorization** — atomic permissions (`users.view`, `users.manage`, `roles.manage`, …) enforced on every endpoint via `[RequirePermission]`
-- **Role hierarchy protection** — SuperAdmin > Admin > User, with privilege escalation prevention (can't assign roles at or above your own rank)
-- **Self-protection rules** — can't lock your own account, can't delete yourself, can't remove your own roles
-- **System role guards** — SuperAdmin/Admin/User cannot be deleted or renamed, SuperAdmin permissions are implicit (never stored in DB)
-- **Frontend mirrors backend** — route guards, nav filtering, and conditional rendering use the same permission claims, but the backend is always authoritative
+- **Permission-based authorization** - atomic permissions (`users.view`, `users.manage`, `roles.manage`, ...) enforced on every endpoint via `[RequirePermission]`
+- **Role hierarchy protection** - SuperAdmin > Admin > User, with privilege escalation prevention (can't assign roles at or above your own rank, can't grant permissions you don't have)
+- **Self-protection rules** - can't lock your own account, can't delete yourself, can't remove your own roles
+- **System role guards** - SuperAdmin/Admin/User cannot be deleted or renamed, SuperAdmin permissions are implicit (never stored in DB)
+- **Frontend mirrors backend** - route guards, nav filtering, and conditional rendering use the same permission claims, but the backend is always authoritative
+
+## PII Compliance
+
+- **`users.view_pii` permission** - personal data (email, phone) is only visible to users with this specific permission. All other users see masked values
+- **Server-side masking** - PII is masked at the API layer, not the frontend. `j***@g***.com` for emails, `***` for phone numbers. No PII leaks through the API regardless of client
+- **Self-view exemption** - users can always see their own data
+- **No PII in logs, URLs, or errors** - email addresses, tokens, and personal data are never included in log output, URL parameters, or error responses
 
 ## Transport & Headers
 
-- **CORS production safeguard** — startup guard rejects `AllowAllOrigins` in non-development environments
-- **CSP with nonce mode** — script-src locked down, Turnstile CAPTCHA whitelisted explicitly
-- **Security headers on every response** — `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, HSTS in production
-- **CSRF protection** — Origin header validation in the SvelteKit API proxy for all state-changing requests
+- **CORS production safeguard** - startup guard rejects `AllowAllOrigins` in non-development environments
+- **CSP with nonce mode** - script-src locked down, Turnstile CAPTCHA whitelisted explicitly
+- **Security headers on every response** - `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, HSTS in production
+- **CSRF protection** - Origin header validation in the SvelteKit API proxy for all state-changing requests
 
 ## Rate Limiting & Input Validation
 
-- **Rate limiting** — global + per-endpoint policies (registration has stricter limits), configurable per environment, with IP and user partitioning
-- **Input validation everywhere** — FluentValidation on backend (even if frontend already validates), Data Annotations flowing into OpenAPI spec
+- **Rate limiting** - global + per-endpoint policies (registration has stricter limits), configurable per environment, with IP and user partitioning
+- **Visible feedback** - rate-limited actions show countdown timers ("Wait Xs") instead of silently failing
+- **Input validation everywhere** - FluentValidation on backend (even if frontend already validates), Data Annotations flowing into OpenAPI spec
 
-## Data Protection
+## Data Protection & Audit
 
-- **Soft delete** — nothing is ever truly gone, every mutation tracked with who/when audit fields
-- **Audit trail** — automatic `CreatedAt/By`, `UpdatedAt/By`, `DeletedAt/By` on every entity via EF Core interceptor
-- **Dev config stripping** — `appsettings.Development.json` and `appsettings.Testing.json` excluded from production Docker images
+- **Full audit trail** - append-only `AuditEvents` table with JSONB metadata, 25+ action constants covering login, registration, password changes, role modifications, OAuth connections, 2FA changes, and admin actions
+- **Soft delete** - nothing is ever truly gone, every mutation tracked with who/when audit fields (`CreatedAt/By`, `UpdatedAt/By`, `DeletedAt/By`)
+- **Dev config stripping** - `appsettings.Development.json` and `appsettings.Testing.json` excluded from production Docker images
 
 ## Reporting a Vulnerability
 
-Found a security issue? Please report it privately — see [SECURITY.md](../SECURITY.md) for the full disclosure policy.
+Found a security issue? Please report it privately - see [SECURITY.md](../SECURITY.md) for the full disclosure policy.


### PR DESCRIPTION
## Summary

Comprehensive documentation update reflecting the major features added in the last week (PRs #340-#425). The existing docs were significantly behind the codebase.

**Added coverage for:**
- OAuth/OIDC external login with 8 providers (Google, GitHub, Discord, Apple, Microsoft, Facebook, LinkedIn, X) - admin-configurable from the UI with AES-256-GCM encrypted credentials
- TOTP two-factor authentication with recovery codes, challenge token flow, and admin disable
- Cmd+K command palette with permission-gated navigation
- PII compliance (server-side masking, `users.view_pii` permission)
- Full audit trail with 25+ action constants
- Claude Code native skills integration (20 skills)
- shadcn-svelte component library (Table, Sidebar, Command, Breadcrumb, InputOTP)
- MailPit local email testing via Aspire
- OAuth security details (state tokens, TOCTOU hardening, encrypted credentials)

**Files updated:**
- `README.md` - New tagline, expanded "Why NETrock" and "What You Get", new Claude Code Integration section
- `docs/features.md` - Added OAuth, 2FA, command palette, PII compliance, audit trail, loading states, Claude Code skills. New "What Your Users Get" section for end-user perspective
- `docs/security.md` - New sections for 2FA security, OAuth security, PII compliance, expanded audit trail
- `docs/architecture.md` - OAuth providers in diagram, updated project structure with new component folders
- `docs/development.md` - New Email Testing and Claude Code Skills sections
- `docs/before-you-ship.md` - Added OAuth encryption key and provider configuration checklist items

## Test Plan
- [ ] Read through all docs for accuracy and completeness
- [ ] Verify all internal links work
- [ ] Check that DeepWiki re-indexes correctly after merge