### PR TITLE
feat: add /create-release skill and fix skill count

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -1,0 +1,66 @@
+---
+disable-model-invocation: true
+argument-hint: "[major|minor|patch] or [vX.Y.Z]"
+---
+
+Creates a GitHub release with auto-generated release notes.
+
+## Hard rules
+
+- **Only release from master.** If not on master, switch first.
+- **No Co-Authored-By lines** in commits.
+- **Sign all tags** with `-S` flag.
+- Releases use **semantic versioning** (vMAJOR.MINOR.PATCH).
+
+## Steps
+
+1. Ensure you are on `master` and up to date: `git checkout master && git pull`
+
+2. Determine the version:
+   - If the user provided a version (e.g., `v1.2.3`), use it
+   - If the user provided a bump type (`major`, `minor`, `patch`), calculate from the latest tag:
+     ```bash
+     git tag --list 'v*' --sort=-v:refname | head -1
+     ```
+   - If no argument and no tags exist, ask the user what version to use
+   - If no argument but tags exist, default to `patch` bump
+
+3. Check what changed since the last release:
+   ```bash
+   # If previous tag exists:
+   git log <previous-tag>..HEAD --oneline
+   # If first release:
+   git log --oneline -50
+   ```
+
+4. Generate release notes by categorizing merged PRs and commits since the last tag. Group changes into these categories (omit empty categories):
+   - **New Features** - `feat:` commits and feature PRs
+   - **Security** - `security:` or security-related changes
+   - **Bug Fixes** - `fix:` commits
+   - **Improvements** - `refactor:`, `perf:` commits
+   - **Documentation** - `docs:` commits
+   - **Infrastructure** - `chore:`, `ci:`, `build:` commits
+
+   Format each entry as: `- Description (#PR)` where possible.
+
+   Add a brief intro paragraph summarizing the release highlights before the categories.
+
+5. Create the tag and release:
+   ```bash
+   git tag -a <version> -m "Release <version>"
+   git push origin <version>
+   gh release create <version> --title "<version>" --notes "<release-notes>"
+   ```
+
+6. Report the release URL.
+
+## Version Bumping Reference
+
+Given `vMAJOR.MINOR.PATCH`:
+- `major` - breaking changes or major milestones (v1.0.0 -> v2.0.0)
+- `minor` - new features, no breaking changes (v1.0.0 -> v1.1.0)
+- `patch` - bug fixes, docs, refactors (v1.0.0 -> v1.0.1)
+
+## First Release
+
+For the very first release (no prior tags), review the full project scope and write release notes that highlight the key capabilities of the project as shipped. This is the launch announcement.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Add your domain entities, services, and pages - the architecture guides you.
 
 ## Claude Code Integration
 
-NETrock ships with 20 native [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills that automate common development workflows. Type `/` in Claude Code to see all available skills.
+NETrock ships with 20+ native [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills that automate common development workflows. Type `/` in Claude Code to see all available skills.
 
 | Skill | What it does |
 |---|---|
@@ -119,8 +119,9 @@ NETrock ships with 20 native [Claude Code](https://docs.anthropic.com/en/docs/cl
 | `/review-pr` | Review a PR for production-readiness |
 | `/review-design` | Review frontend components for UI/UX standards |
 | `/create-issue` | Create a GitHub issue with labels |
+| `/create-release` | Create a GitHub release with auto-generated notes |
 
-The project also includes `CLAUDE.md`, `AGENTS.md`, and `FILEMAP.md` - structured context files that give Claude Code deep understanding of the architecture, conventions, and change impact across the codebase. No separate onboarding needed - Claude Code reads the project and follows the rules.
+Skills are also loaded automatically when Claude Code plans work - it reads the relevant skill and follows the procedure without you having to invoke it. The project also includes `CLAUDE.md`, `AGENTS.md`, and `FILEMAP.md` - structured context files that give Claude Code deep understanding of the architecture, conventions, and change impact across the codebase. No separate onboarding needed.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,7 +28,7 @@ MailPit captures all outgoing emails locally. Access the MailPit web UI from the
 
 ## Claude Code Skills
 
-NETrock ships with 20 native Claude Code skills that automate common development tasks. Type `/` in Claude Code to see all available skills.
+NETrock ships with 20+ native Claude Code skills that automate common development tasks. Type `/` in Claude Code to see all available skills.
 
 Key skills for daily development:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -67,7 +67,7 @@
 | **Dependabot** | Weekly NuGet, npm, and GitHub Actions updates with grouped minor+patch PRs |
 | **Environment Config** | `.env` overrides for everything, documented precedence, working dev defaults out of the box |
 | **Production Hardening** | Dev config stripping from production images, reverse proxy trust configuration, CORS production safeguard |
-| **Claude Code Skills** | 20 native skills for development workflows - feature scaffolding, endpoint creation, PR management, design review, type generation. Project-aware context files (`CLAUDE.md`, `AGENTS.md`, `FILEMAP.md`) for deep codebase understanding |
+| **Claude Code Skills** | 20+ native skills for development workflows - feature scaffolding, endpoint creation, PR management, design review, type generation. Project-aware context files (`CLAUDE.md`, `AGENTS.md`, `FILEMAP.md`) for deep codebase understanding |
 
 ## What Your Users Get
 


### PR DESCRIPTION
## Summary
- Add `/create-release` Claude Code skill for creating GitHub releases with auto-generated categorized release notes and semantic versioning
- Fix skill count from "20" to "20+" across README and docs (evergrowing list)
- Add `/create-release` to the README skills table
- Add note about Claude Code auto-loading skills during planning

## Breaking Changes
None

## Test Plan
- [x] Skill file follows project conventions (YAML frontmatter, steps, hard rules)
- [x] README skills table renders correctly
- [x] Skill count is consistent across all docs

Closes #N/A