### PR TITLE
fix: clean up Claude workflow files during init

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -657,6 +657,10 @@ $templateFiles = @(
     ".github/workflows/claude-code-review.yml"
 )
 
+$templateDirs = @(
+    "docs/sessions"
+)
+
 $ErrorActionPreference = "Continue"
 
 # Stage files for deletion in git BEFORE physically removing them
@@ -665,6 +669,12 @@ if ($DoCommit) {
         $fullPath = Join-Path $ScriptDir $f
         if (Test-Path $fullPath) {
             $null = git rm -f $f 2>&1
+        }
+    }
+    foreach ($d in $templateDirs) {
+        $fullPath = Join-Path $ScriptDir $d
+        if (Test-Path $fullPath) {
+            $null = git rm -rf $d 2>&1
         }
     }
     # Stage init.ps1 for deletion but keep it on disk for now (script is still running)
@@ -678,6 +688,12 @@ else {
         $fullPath = Join-Path $ScriptDir $f
         if (Test-Path $fullPath) {
             Remove-Item $fullPath -Force
+        }
+    }
+    foreach ($d in $templateDirs) {
+        $fullPath = Join-Path $ScriptDir $d
+        if (Test-Path $fullPath) {
+            Remove-Item $fullPath -Recurse -Force
         }
     }
 }

--- a/init.sh
+++ b/init.sh
@@ -639,13 +639,23 @@ TEMPLATE_FILES=(
     ".github/workflows/claude-code-review.yml"
 )
 
+TEMPLATE_DIRS=(
+    "docs/sessions"
+)
+
 if git rev-parse --git-dir > /dev/null 2>&1; then
     for f in "${TEMPLATE_FILES[@]}"; do
         git rm -f "$f" >/dev/null 2>&1 || rm -f "$f"
     done
+    for d in "${TEMPLATE_DIRS[@]}"; do
+        git rm -rf "$d" >/dev/null 2>&1 || rm -rf "$d"
+    done
 else
     for f in "${TEMPLATE_FILES[@]}"; do
         rm -f "$f"
+    done
+    for d in "${TEMPLATE_DIRS[@]}"; do
+        rm -rf "$d"
     done
 fi
 


### PR DESCRIPTION
## Summary
- Adds `claude.yml` and `claude-code-review.yml` to the template cleanup step in both `init.sh` and `init.ps1`
- These workflows are specific to the netrock template repo and should not ship to initialized projects
- Renames the step from "Cleaning up init scripts" to "Cleaning up template files" to reflect broader scope

## Test plan
- [ ] Run `init.sh --name TestProject --no-aspire --no-migration -y` and verify Claude workflow files are deleted
- [ ] Verify `ci.yml` and `docker.yml` are preserved