### PR TITLE
fix(deps): bump MailKit to 4.15.1 for MimeKit CVE

### DIFF
--- a/src/backend/Directory.Packages.props
+++ b/src/backend/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.3.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageVersion Include="Fluid.Core" Version="2.31.0" />
-    <PackageVersion Include="MailKit" Version="4.15.0" />
+    <PackageVersion Include="MailKit" Version="4.15.1" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(FrameworkVersion)" />


### PR DESCRIPTION
## Summary
- Bump MailKit 4.15.0 -> 4.15.1 to resolve transitive MimeKit 4.15.0 CRLF injection vulnerability (GHSA-g7hc-96xr-gvvx)
- MimeKit 4.15.0 allowed SMTP command injection via quoted local-part parsing (moderate severity)

## Breaking Changes
None

## Test Plan
- [x] Backend: `dotnet build && dotnet test -c Release`
- [x] Verify 0 NU1902 warnings in build output