### PR TITLE
fix: use superuser@test.com / Superuser123! as default seed credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ That's it. Aspire starts all infrastructure (PostgreSQL, MinIO) as containers an
 | **Frontend** | `http://localhost:<BASE_PORT>` (default: `http://localhost:13000`) |
 | **MailPit (Email Testing)** | `http://localhost:<BASE_PORT + 8>` |
 
-A Superuser is seeded with credentials you provide during `init.sh` / `init.ps1` (defaults: `admin@localhost` / `Admin123!`). Configured in `appsettings.Development.json`.
+A Superuser is seeded with credentials you provide during `init.sh` / `init.ps1` (defaults: `superuser@test.com` / `Superuser123!`). Configured in `appsettings.Development.json`.
 
 ### 3. Start Building
 

--- a/docs/sessions/2026-03-08-rename-superadmin-to-superuser.md
+++ b/docs/sessions/2026-03-08-rename-superadmin-to-superuser.md
@@ -44,7 +44,7 @@ Renamed the `SuperAdmin` role to `Superuser` across backend, frontend, tests, do
 
 ### Init script credential prompting
 
-- **Choice**: Prompt for Superuser email/password during init with defaults (`admin@localhost` / `Admin123!`)
+- **Choice**: Prompt for Superuser email/password during init with defaults (`superuser@test.com` / `Superuser123!`)
 - **Alternatives considered**: Keep hardcoded credentials, generate random password
 - **Reasoning**: Prompting personalizes the dev environment from the start. Sensible defaults keep the non-interactive (`--yes`) flow fast. Random passwords would require users to look up credentials every time.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -416,7 +416,7 @@ See `appsettings.json` for the full configuration structure and [Before You Ship
 
 ### Which user should I log in as?
 
-A single Superuser is seeded with credentials you provided during `init.sh` / `init.ps1` (defaults: `admin@localhost` / `Admin123!`). Configured in `appsettings.Development.json` under `Seed:Users`. You can add more seed users there if needed.
+A single Superuser is seeded with credentials you provided during `init.sh` / `init.ps1` (defaults: `superuser@test.com` / `Superuser123!`). Configured in `appsettings.Development.json` under `Seed:Users`. You can add more seed users there if needed.
 
 Use the Superuser for full access. Create additional users with lower roles to test authorization guards.
 

--- a/init.ps1
+++ b/init.ps1
@@ -30,10 +30,10 @@
     Don't launch Aspire after setup.
 
 .PARAMETER Email
-    Superuser email address. Default is admin@localhost.
+    Superuser email address. Default is superuser@test.com.
 
 .PARAMETER Password
-    Superuser password. Default is Admin123!.
+    Superuser password. Default is Superuser123!.
 
 .EXAMPLE
     .\init.ps1
@@ -63,9 +63,9 @@ param (
     [switch]$Yes,
 
     [Alias("e")]
-    [string]$Email = "admin@localhost",
+    [string]$Email = "superuser@test.com",
 
-    [string]$Password = "Admin123!",
+    [string]$Password = "Superuser123!",
 
     [switch]$NoMigration,
     [switch]$NoCommit,

--- a/init.sh
+++ b/init.sh
@@ -11,8 +11,8 @@
 #  Flags:
 #    --name, -n     Project name (required in non-interactive mode)
 #    --port, -p     Base port (default: 13000)
-#    --email, -e    Superuser email (default: admin@localhost)
-#    --password     Superuser password (default: Admin123!)
+#    --email, -e    Superuser email (default: superuser@test.com)
+#    --password     Superuser password (default: Superuser123!)
 #    --yes, -y      Accept all defaults, no prompts
 #    --no-migration Skip migration creation
 #    --no-commit    Skip git commits
@@ -118,8 +118,8 @@ show_help() {
     echo "Options:"
     echo "  -n, --name NAME       Project name (e.g., MyAwesomeApi)"
     echo "  -p, --port PORT       Base port for services (default: 13000)"
-    echo "  -e, --email EMAIL     Superuser email (default: admin@localhost)"
-    echo "      --password PASS   Superuser password (default: Admin123!)"
+    echo "  -e, --email EMAIL     Superuser email (default: superuser@test.com)"
+    echo "      --password PASS   Superuser password (default: Superuser123!)"
     echo "  -y, --yes             Accept all defaults without prompting"
     echo "      --no-migration    Skip creating initial migration"
     echo "      --no-commit       Skip git commits"
@@ -264,8 +264,8 @@ prompt_checklist() {
 # ─────────────────────────────────────────────────────────────────────────────
 PROJECT_NAME=""
 BASE_PORT=13000
-ADMIN_EMAIL="admin@localhost"
-ADMIN_PASSWORD="Admin123!"
+ADMIN_EMAIL="superuser@test.com"
+ADMIN_PASSWORD="Superuser123!"
 YES_TO_ALL="false"
 CREATE_MIGRATION="ask"
 DO_COMMIT="ask"


### PR DESCRIPTION
## Summary
- Replace `admin@localhost` / `Admin123!` with `superuser@test.com` / `Superuser123!` as default Superuser seed credentials
- `admin@localhost` fails email validation on the frontend
- New defaults match the role name and are immediately recognizable as dev credentials

## Breaking Changes
None

## Test Plan
- [x] Backend: `dotnet build` (0 errors)
- [ ] Run `./init.sh --yes` and verify seed credentials are `superuser@test.com` / `Superuser123!`