### PR TITLE
refactor(frontend): move SystemRoles to permissions.ts for feature gating

### DIFF
--- a/src/frontend/src/lib/utils/permissions.ts
+++ b/src/frontend/src/lib/utils/permissions.ts
@@ -4,7 +4,13 @@
  */
 
 import type { User } from '$lib/types';
-import { SystemRoles } from './roles';
+
+/** Well-known system role names. Mirrors backend AppRoles constants. */
+export const SystemRoles = {
+	Superuser: 'Superuser',
+	Admin: 'Admin',
+	User: 'User'
+} as const;
 
 export const Permissions = {
 	Users: {

--- a/src/frontend/src/lib/utils/roles.ts
+++ b/src/frontend/src/lib/utils/roles.ts
@@ -3,12 +3,7 @@
  * Mirrors the backend AppRoles.GetRoleRank() logic.
  */
 
-/** Well-known system role names. Mirrors backend AppRoles constants. */
-export const SystemRoles = {
-	Superuser: 'Superuser',
-	Admin: 'Admin',
-	User: 'User'
-} as const;
+import { SystemRoles } from './permissions';
 
 const ROLE_RANKS: Record<string, number> = {
 	[SystemRoles.Superuser]: 3,


### PR DESCRIPTION
## Summary

- Moves `SystemRoles` constant from `roles.ts` into `permissions.ts` where it's actually consumed by core auth (`isSuperuser()`)
- `roles.ts` now imports `SystemRoles` from `permissions.ts` instead of defining it
- This decouples the core auth constant from admin-only role hierarchy utilities (`getRoleRank`, `canManageUser`, `getAssignableRoles`)

## Why

Preparation for netrock-cli generator feature gating. When the `admin` feature is disabled, `roles.ts` (role management utilities) needs to be fully excludable without breaking `permissions.ts` (core auth). Previously, `permissions.ts` imported `SystemRoles` from `roles.ts`, creating a hard dependency on admin-only code.

## Test plan

- [x] All 286 frontend tests pass
- [x] Lint clean
- [x] Type check clean (0 errors)
- [x] All existing consumers of `SystemRoles` via `$lib/utils` barrel export continue to work (verified via svelte-check)