### PR TITLE
fix(a11y): increase EmailVerificationBanner button touch targets to 44px

### DIFF
--- a/src/frontend/src/lib/components/auth/EmailVerificationBanner.svelte
+++ b/src/frontend/src/lib/components/auth/EmailVerificationBanner.svelte
@@ -41,11 +41,10 @@
 		role="alert"
 	>
 		<MailWarning class="h-4 w-4 shrink-0" />
-		<span class="flex-1">{m.auth_emailBanner_message()}</span>
+		<span class="min-w-0 flex-1">{m.auth_emailBanner_message()}</span>
 		<Button
 			variant="ghost"
-			size="sm"
-			class="h-auto px-2 py-1 text-xs font-medium hover:bg-warning/20"
+			class="min-h-11 shrink-0 px-2 text-xs font-medium hover:bg-warning/20"
 			disabled={isResending || cooldown.active}
 			onclick={resend}
 		>
@@ -59,8 +58,8 @@
 		</Button>
 		<Button
 			variant="ghost"
-			size="icon-sm"
-			class="text-warning-foreground/60 hover:bg-warning/20 hover:text-warning-foreground"
+			size="icon"
+			class="min-h-11 min-w-11 text-warning-foreground/60 hover:bg-warning/20 hover:text-warning-foreground"
 			onclick={() => (isDismissed = true)}
 			aria-label={m.common_close()}
 		>


### PR DESCRIPTION
## Summary
- Resend button touch target increased to 44px minimum - removed `h-auto py-1` override that was capping height at ~24px, replaced with `min-h-11`
- Close (X) button touch target increased to 44px minimum - upgraded from `size="icon-sm"` (32px) to `size="icon"` with `min-h-11 min-w-11`
- Added `min-w-0` to message span to prevent flex text overflow on narrow viewports (320px, long i18n strings)
- Added `shrink-0` to resend button to prevent it from collapsing on narrow screens

## Breaking Changes
None

## Test Plan
- [ ] Verify resend button renders at least 44px tall on mobile
- [ ] Verify close button renders at least 44x44px on mobile
- [ ] Test with Czech locale (longer strings) on 320px width - no text overflow
- [ ] Confirm banner still looks compact and consistent on desktop
- [ ] Verify both buttons are easy to tap on a real touch device
- [ ] Frontend: `pnpm run test && pnpm run check`