### PR TITLE
fix(aspire): bump AppHost SDK to 13.2.0

### DIFF
--- a/src/backend/MyProject.AppHost/MyProject.AppHost.csproj
+++ b/src/backend/MyProject.AppHost/MyProject.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.2">
+<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary

- Aspire.Hosting.PostgreSQL/JavaScript were bumped to 13.2.0 by Dependabot, but the AppHost SDK version in the .csproj was left at 13.1.2
- Aspire 13.2 requires the SDK and hosting packages to match, causing a startup failure

## Test plan

- [x] `dotnet build` succeeds
- [ ] `dotnet run --project src/backend/MyProject.AppHost` starts successfully