### PR TITLE
chore(backend): remove unused Asp.Versioning.Mvc.ApiExplorer package

### DIFF
--- a/src/backend/Directory.Packages.props
+++ b/src/backend/Directory.Packages.props
@@ -9,7 +9,6 @@
 
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageVersion Include="Fluid.Core" Version="2.31.0" />
     <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />

--- a/src/backend/MyProject.WebApi/MyProject.WebApi.csproj
+++ b/src/backend/MyProject.WebApi/MyProject.WebApi.csproj
@@ -8,7 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
         <PackageReference Include="Hangfire.AspNetCore" />
         <PackageReference Include="FluentValidation.AspNetCore" />


### PR DESCRIPTION
## Context

While reviewing the open Dependabot PRs, **#487** proposed bumping `Asp.Versioning.Mvc.ApiExplorer` 8.1.1 -> 10.0.0 (a major bump carrying a breaking OpenAPI change: api-version params emitted as `enum` instead of `default`).

Investigation found the package is **dead code**: declared in `Directory.Packages.props` and referenced in `MyProject.WebApi.csproj`, but **never used** anywhere -- no `AddApiVersioning()`, no `[ApiVersion]` attributes, no `ApiExplorer` / `IApiVersionDescriptionProvider` wiring. API versioning is not configured, so the package contributes nothing to the build or the OpenAPI document.

Rather than bump an unused dependency (and inherit its breaking change), this PR removes it.

## Change

- Drop `Asp.Versioning.Mvc.ApiExplorer` from `Directory.Packages.props`
- Drop the `<PackageReference>` from `MyProject.WebApi.csproj`

Two lines, purely subtractive.

## Verification

- `dotnet build -c Release`: 0 warnings, 0 errors
- `dotnet test -c Release`: **1042 passed, 0 failed** (Unit 97, Architecture 10, Component 541 +14 skipped, Api 394)

## Follow-up

Supersedes Dependabot **#487**, which will be closed in favour of this removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)