### PR TITLE
chore(backend): bump Aspire.AppHost.Sdk to 13.4.6

### DIFF
--- a/src/backend/MyProject.AppHost/MyProject.AppHost.csproj
+++ b/src/backend/MyProject.AppHost/MyProject.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- `Aspire.AppHost.Sdk` 13.2.0 -> 13.4.6 so the AppHost SDK matches the `Aspire.Hosting.*` 13.4.6 packages updated in #523 (missed there).

## Breaking Changes
None

## Test Plan
- [x] Backend: `dotnet build` succeeds
- [ ] CI green