### PR TITLE
fix(frontend): buffer proxied bodies so 401 responses pass through

### DIFF
--- a/src/frontend/src/routes/api/[...path]/+server.ts
+++ b/src/frontend/src/routes/api/[...path]/+server.ts
@@ -163,12 +163,17 @@ export const fallback: RequestHandler = async ({
 	const queryString = targetParams.toString();
 	const targetUrl = `${SERVER_CONFIG.API_URL}/api/${params.path}${queryString ? `?${queryString}` : ''}`;
 
+	// Buffer the body instead of forwarding the incoming ReadableStream. undici
+	// (Node 24.14 - 24.15) turns any 401 backend response into a network error
+	// when the request body is a stream without a byte source ("expected
+	// non-null body source"), which the proxy would surface as a 502 instead of
+	// the real 401 (nodejs/undici#5018).
+	const body = request.body ? await request.arrayBuffer() : null;
+
 	const newRequest = new Request(targetUrl, {
 		method: request.method,
 		headers: filterRequestHeaders(request.headers, getClientAddress()),
-		body: request.body,
-		// @ts-expect-error - duplex is needed for streaming bodies in some node versions/fetch implementations
-		duplex: 'half'
+		body
 	});
 
 	try {

--- a/src/frontend/src/routes/api/proxy.test.ts
+++ b/src/frontend/src/routes/api/proxy.test.ts
@@ -568,10 +568,7 @@ describe('API proxy - request body forwarding', () => {
 	}
 
 	it('buffers a streamed request body before proxying', async () => {
-		// Regression: forwarding the incoming ReadableStream as-is leaves the
-		// proxied request without a byte source, which undici (Node 24.14-24.15)
-		// rejects with "expected non-null body source" on every 401 backend
-		// response - turning a wrong password into a 502 (nodejs/undici#5018).
+		// Regression for nodejs/undici#5018 (see the proxy handler for details).
 		const payload = '{"username":"user@example.com","password":"wrong"}';
 		const event = mockProxyEvent({
 			method: 'POST',

--- a/src/frontend/src/routes/api/proxy.test.ts
+++ b/src/frontend/src/routes/api/proxy.test.ts
@@ -67,9 +67,10 @@ function mockProxyEvent(
 		requestHeaders.set('origin', origin);
 	}
 
-	const requestInit: RequestInit = { method, headers: requestHeaders };
+	const requestInit: RequestInit & { duplex?: 'half' } = { method, headers: requestHeaders };
 	if (body && method !== 'GET' && method !== 'HEAD') {
 		requestInit.body = body;
+		requestInit.duplex = 'half';
 	}
 	const request = new Request(url.toString(), requestInit);
 
@@ -552,6 +553,48 @@ describe('API proxy - URL construction and cookie auth paths', () => {
 		await fallback(event);
 
 		expect(getProxiedRequest(event).method).toBe('PUT');
+	});
+});
+
+describe('API proxy - request body forwarding', () => {
+	/** Wraps a payload in a ReadableStream, matching what SvelteKit hands the proxy. */
+	function streamBody(payload: string): ReadableStream<Uint8Array> {
+		return new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(payload));
+				controller.close();
+			}
+		});
+	}
+
+	it('buffers a streamed request body before proxying', async () => {
+		// Regression: forwarding the incoming ReadableStream as-is leaves the
+		// proxied request without a byte source, which undici (Node 24.14-24.15)
+		// rejects with "expected non-null body source" on every 401 backend
+		// response - turning a wrong password into a 502 (nodejs/undici#5018).
+		const payload = '{"username":"user@example.com","password":"wrong"}';
+		const event = mockProxyEvent({
+			method: 'POST',
+			path: 'auth/login',
+			origin: 'http://localhost:5173',
+			headers: { 'content-type': 'application/json' },
+			body: streamBody(payload),
+			fetchResponse: new Response('{"title":"Unauthorized"}', { status: 401 })
+		});
+
+		const response = await fallback(event);
+
+		expect(response.status).toBe(401);
+		expect(event.request.bodyUsed).toBe(true);
+		expect(await getProxiedRequest(event).text()).toBe(payload);
+	});
+
+	it('does not attach a body to bodyless requests', async () => {
+		const event = mockProxyEvent({ method: 'GET' });
+
+		await fallback(event);
+
+		expect(getProxiedRequest(event).body).toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Summary
- The BFF proxy (`src/routes/api/[...path]/+server.ts`) forwarded the incoming `ReadableStream` as the outgoing request body. undici 7.24.x (bundled with Node 24.14 - 24.15) turns every 401 backend response into a network error (`fetch failed: expected non-null body source`, nodejs/undici#5018) when the request body has no byte source, so a wrong password surfaced as a 502 and the "API offline" page instead of the "Invalid username or password." toast.
- Buffer the request body into an `ArrayBuffer` before building the proxied `Request` so undici always has a byte source; drop the now-unneeded `duplex` option.
- Add a vitest regression test that feeds a streamed body through the proxy (fails on master, passes with the fix).

Closes #481

## Breaking Changes
None

## Test Plan
- [x] Reproduced on master: adapter-node build running on `node:24.15-alpine` against the real backend, `POST /api/auth/login` with a wrong password -> 502 + `expected non-null body source` in the frontend log
- [x] Same setup with the fix -> 401 ProblemDetails (`Invalid username or password.`) passed through; correct credentials -> 200 with cookies, `GET /api/users/me` works
- [x] Confirmed the fix on Node 22 / 24.13 / 24.16+ (undici 6.28 / 7.18 / 7.25+) still returns 401 for both stream and buffered bodies
- [x] Fresh init (`./init.sh --name Test --port 15000 --yes --no-commit --no-aspire`): backend build + tests green, frontend tests + check green, fix present
- [x] Backend: unchanged
- [x] Frontend: `pnpm run test && pnpm run format && pnpm run lint && pnpm run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)