### PR TITLE
feat: add machine-readable error codes to ProblemDetails

### DIFF
--- a/.claude/agents/backend-reviewer.md
+++ b/.claude/agents/backend-reviewer.md
@@ -18,7 +18,7 @@ WebApi -> Application <- Infrastructure
 All layers reference Shared (Result, ErrorType, ErrorMessages)
 ```
 
-- **Shared**: `Result`/`Result<T>`, `ErrorType`, `ErrorMessages`. Zero deps.
+- **Shared**: `Result`/`Result<T>`, `Error` (code + message), `ErrorType`, `ErrorMessages`. Zero deps.
 - **Domain**: Entities (`BaseEntity`). Zero deps.
 - **Application**: Interfaces, DTOs (Input/Output), service contracts.
 - **Infrastructure**: EF Core, Identity, services. All implementations `internal`.
@@ -28,7 +28,7 @@ All layers reference Shared (Result, ErrorType, ErrorMessages)
 
 ### Result Pattern
 - All fallible operations return `Result`/`Result<T>` - never throw for business logic
-- `Result.Failure(ErrorMessages.*, ErrorType.*)` with centralized constants
+- `Result.Failure(ErrorMessages.*, ErrorType.*)` with centralized `Error` entries (stable snake_case `code` + message; never rename a code)
 - Runtime values in logs, never in Result messages
 - Controllers use `ProblemFactory.Create(result.Error, result.ErrorType)` for failures
 

--- a/.claude/agents/fullstack-engineer.md
+++ b/.claude/agents/fullstack-engineer.md
@@ -24,7 +24,7 @@ Backend DTO -> OpenAPI spec -> v1.d.ts (generated) -> Frontend type aliases -> C
 ```
 
 ```
-Backend ErrorMessages.* -> Result.Failure() -> ProblemFactory.Create() -> ProblemDetails.detail -> Frontend getErrorMessage()
+Backend ErrorMessages.* (Error: code + message) -> Result.Failure() -> ProblemFactory.Create() -> ProblemDetails.detail + code -> Frontend getErrorMessage(error, fallback, messagesByCode) / getErrorCode()
 ```
 
 ## Implementation Order

--- a/.claude/rules/backend-api.md
+++ b/.claude/rules/backend-api.md
@@ -4,7 +4,7 @@ Extends CLAUDE.md Hard Rules with implementation patterns.
 
 ## Error Handling
 - `ProblemFactory.Create(result.Error, result.ErrorType)` for error responses - never `NotFound()`, `BadRequest()`, or anonymous objects
-- Client-facing error messages: `ErrorMessages.*` constants only - runtime values go in `ILogger`, never in `Result.Failure()`
+- Client-facing errors: `ErrorMessages.*` entries only (`Error` = stable snake_case `code` + message) - runtime values go in `ILogger`, never in `Result.Failure()`. Every ProblemDetails carries `code`; renaming a code is a breaking change
 
 ## Controllers
 - Authenticated endpoints extend `ApiController` - public endpoints use `ControllerBase` directly

--- a/.claude/rules/frontend-svelte.md
+++ b/.claude/rules/frontend-svelte.md
@@ -7,7 +7,7 @@ Extends CLAUDE.md Hard Rules with implementation patterns.
 
 ## API Client
 - File uploads: native `fetch()` with `FormData` - not `browserClient` (openapi-fetch breaks with multipart)
-- Error handling: `getErrorMessage(error, fallback)` for simple errors, `handleMutationError()` for forms with validation
+- Error handling: `getErrorMessage(error, fallback)` for simple errors, `getErrorMessage(error, fallback, messagesByCode)` / `getErrorCode()` to translate by backend `code` (never match `detail` text), `handleMutationError()` for forms with validation
 
 ## Styling
 - `h-dvh` not `h-screen` for full-height layouts

--- a/.claude/skills/backend-conventions/SKILL.md
+++ b/.claude/skills/backend-conventions/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: false
 
 ```
 src/backend/
-├── MyProject.Shared/              # Result, ErrorType, ErrorMessages (zero deps)
+├── MyProject.Shared/              # Result, Error, ErrorType, ErrorMessages (zero deps)
 ├── MyProject.Domain/Entities/     # Business entities (BaseEntity)
 ├── MyProject.Application/         # Interfaces, DTOs, service contracts
 │   ├── Features/{Feature}/I{Feature}Service.cs
@@ -90,7 +90,7 @@ dotnet ef migrations add {Name} \
 // Success
 return Result<Guid>.Success(entity.Id);
 
-// Static message - prefer ErrorMessages constants
+// Static error (code + message) - always an ErrorMessages entry
 return Result.Failure(ErrorMessages.Admin.UserNotFound, ErrorType.NotFound);
 
 // Runtime values go in server-side logs, never in client responses
@@ -105,7 +105,7 @@ return Result.Failure(ErrorMessages.Admin.DeleteFailed);
 | `ErrorType.Forbidden` | 403 | Authenticated but insufficient privileges |
 | `ErrorType.NotFound` | 404 | Entity not found |
 
-Controller: `ProblemFactory.Create(result.Error, result.ErrorType)` for failures.
+Controller: `ProblemFactory.Create(result.Error, result.ErrorType)` for failures. `result.Error` is an `Error` record (`Code`, `Message`); the factory writes `Message` to `detail` and `Code` to the `code` extension.
 
 ## Service Pattern
 
@@ -149,13 +149,16 @@ FluentValidation auto-discovered from WebApi assembly. Co-locate validators with
 | URL fields | `Uri.TryCreate` + restrict to `http`/`https` schemes |
 | Shared patterns | Extract to `ValidationConstants.cs` |
 
-## Error Messages
+## Error Messages and Codes
 
-- Client-facing messages are centralized as `const string` in `ErrorMessages.cs` nested classes
+- Client-facing errors are centralized as `static readonly Error` entries in `ErrorMessages.cs` nested classes. `Error(Code, Message)` pairs a stable, machine-readable snake_case code with the human-readable message.
+- Codes are derived from the declaring location: `{nested_class}_{field_name}` in snake_case (`ErrorMessages.ExternalAuth.StateExpired` -> `external_auth_state_expired`). `ErrorMessagesTests` enforces the pattern and global uniqueness.
+- Every `ProblemDetails` response carries the code in the `code` extension (`ProblemFactory` for controllers/middleware, `ProblemFactory.EnsureCode` in `AddProblemDetails` for framework-generated bodies: `validation_failed` for model validation, snake_case reason phrase such as `not_found` otherwise). `ProblemDetailsSchemaTransformer` documents it in OpenAPI.
+- Codes are a public contract: adding one is additive, renaming or removing one is a breaking change for API consumers (frontend maps on codes, not on `detail` text).
 - Runtime values (role names, user IDs, framework errors): log server-side via `ILogger`, never in `Result.Failure()`
-- Identity errors: log `.Description` server-side, return a static `ErrorMessages` constant to the client
-- Exception: password validation errors (registration, change, reset) are forwarded as-is
-- To add: create `const string` in `ErrorMessages.cs` nested class. Dynamic values go in logs, not in Result.
+- Identity errors: log `.Description` server-side, return a static `ErrorMessages` entry to the client
+- Exception: password policy / registration feedback keeps its stable code and overrides only the message: `ErrorMessages.Auth.PasswordPolicyViolation with { Message = errors }`
+- To add: create `public static readonly Error X = new("{class}_{x}", "...")` in the matching `ErrorMessages.cs` nested class. Dynamic values go in logs, not in Result.
 
 ## Authorization
 

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -70,6 +70,18 @@ const { response, error } = await browserClient.POST('/api/...', { body });
 if (!response.ok) toast.error(getErrorMessage(error, m.fallback_message()));
 ```
 
+### Translating Specific Errors
+
+Every backend `ProblemDetails` carries a stable snake_case `code` (see `ErrorMessages.cs`) next to the English `detail`. Branch on `code` - never on `detail` text. Pass an `ErrorMessagesByCode` map to translate known codes; unknown codes fall back to `detail`, then `title`, then the fallback:
+
+```typescript
+import { getErrorMessage } from '$lib/api';
+const message = getErrorMessage(error, m.auth_login_error(), {
+	auth_login_invalid_credentials: m.auth_login_invalidCredentials,
+	auth_login_account_locked: m.auth_login_accountLocked
+});
+```
+
 ### Mutations (Validation + Rate Limiting)
 
 ```typescript

--- a/.claude/skills/new-entity/SKILL.md
+++ b/.claude/skills/new-entity/SKILL.md
@@ -24,7 +24,7 @@ Use these as starting points - fill in the specifics from context:
 1. Create `src/backend/MyProject.Domain/Entities/{Entity}.cs`:
    - Extend `BaseEntity`, private setters, protected parameterless ctor, public ctor with `Id = Guid.NewGuid()`
 2. If enums: create alongside entity with explicit integer values
-3. Add error messages to `src/backend/MyProject.Shared/ErrorMessages.cs`
+3. Add `Error` entries (snake_case code + message) to `src/backend/MyProject.Shared/ErrorMessages.cs`
 
 **Infrastructure:**
 

--- a/.claude/skills/review-pr/references/conventions-summary.md
+++ b/.claude/skills/review-pr/references/conventions-summary.md
@@ -45,7 +45,7 @@
 
 ## Error Flow
 
-Backend `ErrorMessages.*` -> `Result.Failure()` -> `ProblemFactory.Create()` -> `ProblemDetails.detail` -> Frontend `getErrorMessage()`
+Backend `ErrorMessages.*` (`Error`: code + message) -> `Result.Failure()` -> `ProblemFactory.Create()` -> `ProblemDetails.detail` + `code` -> Frontend `getErrorMessage(error, fallback, messagesByCode)` / `getErrorCode()`
 
 ## Dockerfile
 

--- a/FILEMAP.md
+++ b/FILEMAP.md
@@ -26,8 +26,9 @@ Quick-reference for "when you change X, also update Y" and "where does X live?"
 |---|---|
 | **Domain entity** (add/rename property) | EF configuration, migration, Application DTOs, WebApi DTOs, mapper, frontend types (`pnpm run api:generate`) |
 | **Domain entity** (add enum property) | EF config (`.HasComment()`), `EnumSchemaTransformer` handles the rest automatically |
-| **`ErrorMessages.cs`** (Shared - add/rename constant) | Service that uses it; frontend may display message directly |
-| **`Result.cs`** (Shared - change pattern) | Every service + every controller that matches on `Result` |
+| **`ErrorMessages.cs`** (Shared - add/rename `Error` entry) | Service that uses it; `ErrorMessagesTests` (code must be `{nested_class}_{field_name}` snake_case); frontend `ErrorMessagesByCode` maps keyed on the code (renaming a code is a breaking API change) |
+| **`Result.cs`** / **`Error.cs`** (Shared - change pattern) | Every service + every controller that matches on `Result`; `ProblemFactory` |
+| **`ProblemFactory`** (WebApi - ProblemDetails shape, `code` extension) | `ProblemDetailsSchemaTransformer` (OpenAPI), `ExceptionHandlingMiddleware`, `OriginValidationMiddleware`, `RateLimiterExtensions`, `ProblemDetailsAuthorizationHandler`, `Program.cs` (`EnsureCode`), `ProblemDetailsAssert` + `ProblemDetailsCodeTests` (Api.Tests), frontend `v1.d.ts` regeneration |
 | **Application interface** (change signature) | Infrastructure service implementation, controller calling the service |
 | **Application DTO** (add/rename/remove field) | Infrastructure service, WebApi mapper, WebApi request/response DTO, frontend types |
 | **Infrastructure Options class** | `appsettings.json`, `appsettings.Development.json` (excluded from production publish - see `StripDevConfig`), DI registration |
@@ -79,7 +80,7 @@ Quick-reference for "when you change X, also update Y" and "where does X live?"
 | **Connection string config** (change format/name) | Verify `MyProject.AppHost/Program.cs` environment variable mapping still works |
 | **`MyProject.ServiceDefaults/Extensions.cs`** | All projects referencing ServiceDefaults, `Program.cs` `AddServiceDefaults()` call |
 | **`MyProject.AppHost/Program.cs`** | Verify resource names match `ConnectionStrings:*` and `WithEnvironment` keys match `appsettings.json` option paths |
-| **`ProblemDetailsAuthorizationHandler`** | `ProblemDetails` shape, `ErrorMessages.Auth` constants, `Program.cs` registration |
+| **`ProblemDetailsAuthorizationHandler`** | `ProblemFactory.CreateProblemDetails`, `ErrorMessages.Auth` entries, `Program.cs` registration |
 | **`CaptchaOptions`** (Infrastructure - Captcha config) | `appsettings.json`, `appsettings.Development.json`, `appsettings.Testing.json`, `TurnstileCaptchaService`, `ServiceCollectionExtensions` |
 | **`TurnstileCaptchaService`** (Infrastructure - Captcha service) | `ICaptchaService` interface, `CaptchaOptions`, `AuthController` captcha gate |
 | **`TurnstileWidget.svelte`** (Frontend - Captcha widget) | `RegisterForm.svelte`, `ForgotPasswordForm.svelte`, `app.d.ts` (`Window.turnstile`), `TURNSTILE_SITE_KEY` env var (runtime-configurable via `$env/dynamic/private` and SSR layout data) |
@@ -91,7 +92,7 @@ Quick-reference for "when you change X, also update Y" and "where does X live?"
 | **`$lib/utils/permissions.ts`** (add permission) | Backend `AppPermissions.cs` must have matching constant; update components checking that permission |
 | **`v1.d.ts`** (regenerated) | Type aliases in `$lib/types/index.ts`, any component using changed schemas |
 | **`$lib/api/client.ts`** | Every component using `browserClient` or `createApiClient` |
-| **`$lib/api/error-handling.ts`** | Components that call `getErrorMessage`, `mapFieldErrors`, `isValidationProblemDetails`, `isRateLimited`, `getRetryAfterSeconds`; `mutation.ts` (wraps these utilities) |
+| **`$lib/api/error-handling.ts`** | Components that call `getErrorMessage`, `getErrorCode`, `mapFieldErrors`, `isValidationProblemDetails`, `isRateLimited`, `getRetryAfterSeconds`; `mutation.ts` (wraps these utilities); OAuth callback page and `LoginForm` (`ErrorMessagesByCode` maps) |
 | **`$lib/api/mutation.ts`** | All form components using `handleMutationError()` for rate-limit, validation, and generic error handling |
 | **`$lib/state/cooldown.svelte.ts`** | Components that call `createCooldown` for rate limit button disable |
 | **`$lib/config/server.ts`** | Server load functions that import `SERVER_CONFIG` |
@@ -145,7 +146,7 @@ Files that are frequently referenced in impact tables above. For anything not li
 
 ```
 src/backend/MyProject.{Layer}/
-  Shared:          Result.cs, ErrorType.cs, ErrorMessages.cs, PhoneNumberHelper.cs
+  Shared:          Result.cs, Error.cs, ErrorType.cs, ErrorMessages.cs, PhoneNumberHelper.cs
   Domain:          Entities/{Entity}.cs
   Application:     Features/{Feature}/I{Feature}Service.cs
                    Features/{Feature}/Dtos/{Operation}Input.cs, {Entity}Output.cs
@@ -167,7 +168,8 @@ src/backend/MyProject.{Layer}/
                    Authorization/RequirePermissionAttribute.cs (+ handler, provider, requirement)
                    Authorization/ProblemDetailsAuthorizationHandler.cs
                    Routing/{Name}RouteConstraint.cs
-                   Shared/RateLimitPolicies.cs
+                   Shared/RateLimitPolicies.cs, ProblemFactory.cs
+                   Features/OpenApi/Transformers/{Name}SchemaTransformer.cs
                    Program.cs
 ```
 
@@ -245,6 +247,9 @@ src/backend/tests/
   MyProject.Api.Tests/
     Fixtures/CustomWebApplicationFactory.cs      WebApplicationFactory config
     Fixtures/TestAuthHandler.cs                  Fake auth handler
+    Fixtures/ProblemDetailsAssert.cs             Shared ProblemDetails (status/detail/code) assertions
+    Shared/ProblemFactoryTests.cs                ProblemFactory + code fallback tests
+    Middlewares/ProblemDetailsCodeTests.cs       End-to-end `code` presence across the pipeline
     Contracts/ResponseContracts.cs               Frozen response shapes for contract testing
     Controllers/{Controller}Tests.cs             HTTP integration tests
     Validators/{Validator}Tests.cs               FluentValidation tests
@@ -260,7 +265,7 @@ src/backend/tests/
 |---|---|
 | `src/backend/MyProject.WebApi/Program.cs` | DI wiring, middleware pipeline |
 | `src/backend/MyProject.Infrastructure/Persistence/MyProjectDbContext.cs` | DbSets, migrations |
-| `src/backend/MyProject.Shared/ErrorMessages.cs` | All static error strings |
+| `src/backend/MyProject.Shared/ErrorMessages.cs` | All client-facing errors (`Error` = stable snake_case code + message) |
 | `src/backend/MyProject.Application/Identity/Constants/AppRoles.cs` | Role definitions |
 | `src/backend/MyProject.Application/Identity/Constants/AppPermissions.cs` | Permission definitions (reflection-discovered) |
 | `src/backend/MyProject.Application/Caching/Constants/CacheKeys.cs` | Cache key constants (used across services) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,7 +19,7 @@
 | **Database** | PostgreSQL + EF Core with soft delete, full audit trail (created/updated/deleted by + at), global query filters |
 | **Audit Trail** | Append-only audit events table with JSONB metadata, action constants covering auth, account, admin, role, and OAuth operations. Admin per-user view and user self-activity log |
 | **API Documentation** | OpenAPI spec + Scalar UI, with custom transformers for enums, nullable types, numeric schemas, and camelCase query params |
-| **Error Handling** | Result pattern for business logic, `ProblemDetails` ([RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)) on every error response, structured error messages |
+| **Error Handling** | Result pattern for business logic, `ProblemDetails` ([RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)) on every error response with a stable machine-readable `code` extension alongside the human-readable `detail` |
 | **Logging** | Serilog bridged to OpenTelemetry with structured request logging, correlation, and Aspire Dashboard |
 | **Account Management** | Registration with CAPTCHA, login/logout, remember me, email verification, password reset, profile updates with avatar upload, account deletion, connected OAuth accounts management, set password for OAuth-only users |
 | **Admin Panel API** | User CRUD with search/pagination, custom role management with permission editor, role assignment with hierarchy enforcement, background job management, OAuth provider configuration, 2FA management |

--- a/docs/sessions/2026-08-17-problem-details-error-codes.md
+++ b/docs/sessions/2026-08-17-problem-details-error-codes.md
@@ -1,0 +1,73 @@
+# ProblemDetails Error Codes
+
+**Date**: 2026-08-17
+**Scope**: Machine-readable `code` on every ProblemDetails response (backend), code-based error translation in the frontend (issue #452)
+
+## Summary
+
+Every client-facing error is now an `Error` record (stable snake_case `Code` + human `Message`) declared once in `ErrorMessages.cs`. `Result`/`Result<T>` carry the `Error`, and every `ProblemDetails` body written by the API (controllers, authorization handler, exception middleware, origin validation, rate limiter, model validation, status code pages) exposes the code in a `code` extension next to the unchanged `detail`. The frontend regenerated `v1.d.ts`, gained `getErrorCode()` and a code-keyed `ErrorMessagesByCode` option on `getErrorMessage()`, and the OAuth callback page and `LoginForm` translate by code instead of matching English strings - removing the codebase's last TODO.
+
+## Changes Made
+
+| File | Change | Reason |
+|------|--------|--------|
+| `src/backend/MyProject.Shared/Error.cs` | New `Error(Code, Message)` record | Single value carrying both the machine-readable code and the human message |
+| `src/backend/MyProject.Shared/ErrorMessages.cs` | Every `const string` became `static readonly Error` with a `{class}_{field}` snake_case code; new `FileStorage` group, `Auth.RegistrationInvalid`, `Auth.PasswordPolicyViolation`, `Server.TooManyRequests` | Codes are a public contract and must be centralized; the new entries replace ad-hoc literal messages |
+| `src/backend/MyProject.Shared/Result.cs` | `Error` property and `Failure(...)` overloads take `Error` | Result carries the code through to the controller |
+| `src/backend/MyProject.WebApi/Shared/ProblemFactory.cs` | `Create(Error?, ErrorType?)`, `CreateProblemDetails(Error, status)`, `EnsureCode(ProblemDetails)` | One place that writes `detail` + `code`; fallback codes for framework-generated bodies |
+| `src/backend/MyProject.WebApi/Program.cs` | `ProblemFactory.EnsureCode` in `CustomizeProblemDetails` | Model validation (`validation_failed`) and status code pages (`not_found`, ...) also carry a code |
+| `src/backend/MyProject.WebApi/Middlewares/*`, `Authorization/ProblemDetailsAuthorizationHandler.cs`, `Extensions/RateLimiterExtensions.cs` | Build bodies via `ProblemFactory.CreateProblemDetails` | 401/403/429/500/404 paths carry codes |
+| `src/backend/MyProject.WebApi/Features/OpenApi/Transformers/ProblemDetailsSchemaTransformer.cs` | New schema transformer | Documents `code` on the `ProblemDetails` schema so generated clients see it |
+| `src/backend/MyProject.Infrastructure/...` | Services use `ErrorMessages` entries (S3 storage), `with { Message = ... }` for Identity password/registration feedback | No literal strings in `Result.Failure`, stable code kept for dynamic messages |
+| `src/backend/tests/...` | `ProblemDetailsAssert`, `ProblemFactoryTests`, `ProblemDetailsCodeTests`, `ErrorMessagesTests` code-convention tests, existing tests use `ErrorMessages` entries | Verify code presence across the whole pipeline and enforce the naming convention |
+| `src/frontend/src/lib/api/v1.d.ts` | Regenerated from the API OpenAPI document (dumped via the API test host) | `ProblemDetails.code` typed |
+| `src/frontend/src/lib/api/error-handling.ts` | `ProblemDetails` interface with `code`, `getErrorCode()`, `ErrorMessagesByCode`, `getErrorMessage(error, fallback, messagesByCode?)` | Helpers prefer `code` when a translation exists |
+| `src/frontend/src/lib/components/auth/LoginForm.svelte` | Translate by `auth_login_*` codes | Removes `detail.includes('temporarily locked')` string matching |
+| `src/frontend/src/routes/(public)/oauth/callback/+page.server.ts`, `+page.svelte` | Load returns the backend `code`; page maps codes to messages | Removes the English-string `ERROR_MAP` and the TODO |
+| `src/frontend/src/messages/{en,cs}/oauth.json` | `oauth_callback_invalidState`, `oauth_callback_providerError` | Cover the remaining callback failure codes |
+| `FILEMAP.md`, `.claude/rules/*.md`, `.claude/skills/backend-conventions/SKILL.md`, `.claude/skills/frontend-conventions/SKILL.md`, agents/review references, `docs/features.md` | Document the convention | Single source of truth for the error code contract |
+
+## Decisions & Reasoning
+
+### `Error` record instead of a parallel code constant
+
+- **Choice**: `Error(Code, Message)` record; `ErrorMessages` entries become `static readonly Error`; `Result.Error` is `Error?`
+- **Alternatives considered**: keep `const string` messages and add a separate `ErrorCodes` class; add an optional `string? Code` parameter to `Result.Failure`
+- **Reasoning**: a single value cannot drift (every message has exactly one code), call sites stay `Result.Failure(ErrorMessages.X.Y)`, and `record with { Message = ... }` keeps a stable code for the few dynamic messages (password policy, retry hint)
+
+### Codes derived from the declaring location
+
+- **Choice**: `{nested_class}_{field_name}` snake_case, enforced by `ErrorMessagesTests` (pattern + global uniqueness)
+- **Alternatives considered**: hand-picked short codes
+- **Reasoning**: greppable, collision-free, no bikeshedding; the test makes renames a conscious (breaking) act
+
+### `code` as a ProblemDetails extension, fallback for framework bodies
+
+- **Choice**: `Extensions["code"]`; `EnsureCode` in `AddProblemDetails` gives `validation_failed` to `HttpValidationProblemDetails` and the snake_case reason phrase to anything else without a code
+- **Alternatives considered**: custom `ProblemDetails` subclass; leaving framework-generated bodies without a code
+- **Reasoning**: extension keeps RFC 9457 shape and the existing `ProblemDetails` OpenAPI schema (documented via a schema transformer); every error response having a code is what makes clients able to rely on it
+
+### Frontend maps keyed by code, not `m[code]`
+
+- **Choice**: `ErrorMessagesByCode` maps (`code -> Paraglide message function`) passed to `getErrorMessage`, or looked up directly on the OAuth callback page
+- **Alternatives considered**: use backend codes verbatim as i18n keys and index the Paraglide module dynamically
+- **Reasoning**: keeps the `{domain}_{feature}_{element}` i18n key convention, stays type-safe and tree-shakeable, and unknown codes still fall back to `detail`/`title`/fallback
+
+## Diagrams
+
+```mermaid
+flowchart LR
+    EM[ErrorMessages.X.Y : Error] --> RF[Result.Failure]
+    RF --> PF[ProblemFactory.Create]
+    MW[Middleware / handlers] --> PC[ProblemFactory.CreateProblemDetails]
+    FW[Framework validation / status pages] --> EC[ProblemFactory.EnsureCode]
+    PF --> PD["ProblemDetails { detail, code }"]
+    PC --> PD
+    EC --> PD
+    PD --> FE["getErrorCode / getErrorMessage(error, fallback, messagesByCode)"]
+    FE --> I18N[Paraglide message]
+```
+
+## Follow-Up Items
+
+- [ ] Migrate the remaining `getErrorMessage(apiError, fallback)` call sites to code-keyed translations where a localized message adds value (issue #452 step 4, "gradually migrate")

--- a/src/backend/MyProject.Infrastructure/Features/Admin/Services/AdminService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Admin/Services/AdminService.cs
@@ -596,7 +596,7 @@ internal class AdminService(
 
     /// <summary>
     /// Verifies that the caller has a strictly higher role rank than the target user.
-    /// Returns <see cref="Result.Failure(string)"/> if the hierarchy check fails.
+    /// Returns <see cref="Result.Failure(Error)"/> if the hierarchy check fails.
     /// </summary>
     private async Task<Result> EnforceHierarchyAsync(Guid callerUserId, ApplicationUser targetUser)
     {

--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Services/AuthenticationService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Services/AuthenticationService.cs
@@ -200,7 +200,7 @@ internal class AuthenticationService(
         if (!result.Succeeded)
         {
             var errors = string.Join(", ", result.Errors.Select(e => e.Description));
-            return Result<Guid>.Failure(errors);
+            return Result<Guid>.Failure(ErrorMessages.Auth.RegistrationInvalid with { Message = errors });
         }
 
         var roleResult = await userManager.AddToRoleAsync(user, AppRoles.User);
@@ -266,7 +266,7 @@ internal class AuthenticationService(
         if (!changeResult.Succeeded)
         {
             var errors = string.Join(", ", changeResult.Errors.Select(e => e.Description));
-            return Result.Failure(errors);
+            return Result.Failure(ErrorMessages.Auth.PasswordPolicyViolation with { Message = errors });
         }
 
         await tokenSessionService.RevokeUserTokensAsync(userId.Value, cancellationToken);
@@ -334,7 +334,7 @@ internal class AuthenticationService(
                 return Result.Failure(ErrorMessages.Auth.ResetPasswordTokenInvalid);
             }
 
-            return Result.Failure(string.Join(" ", errors));
+            return Result.Failure(ErrorMessages.Auth.PasswordPolicyViolation with { Message = string.Join(" ", errors) });
         }
 
         emailToken.IsUsed = true;

--- a/src/backend/MyProject.Infrastructure/Features/Authentication/Services/TokenSessionService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/Authentication/Services/TokenSessionService.cs
@@ -195,13 +195,13 @@ internal class TokenSessionService(
         return Result<AuthenticationOutput>.Success(
             new AuthenticationOutput(AccessToken: newAccessToken, RefreshToken: newRefreshTokenString));
 
-        Result<AuthenticationOutput> Fail(string message)
+        Result<AuthenticationOutput> Fail(Error error)
         {
             if (useCookies)
             {
                 DeleteAuthCookies();
             }
-            return Result<AuthenticationOutput>.Failure(message, ErrorType.Unauthorized);
+            return Result<AuthenticationOutput>.Failure(error, ErrorType.Unauthorized);
         }
     }
 

--- a/src/backend/MyProject.Infrastructure/Features/FileStorage/Services/S3FileStorageService.cs
+++ b/src/backend/MyProject.Infrastructure/Features/FileStorage/Services/S3FileStorageService.cs
@@ -47,12 +47,12 @@ internal sealed class S3FileStorageService(
         catch (AmazonS3Exception ex)
         {
             logger.LogError(ex, "Failed to upload object '{Key}' to bucket '{Bucket}'", key, _bucketName);
-            return Result.Failure("Failed to upload file to storage.");
+            return Result.Failure(ErrorMessages.FileStorage.UploadFailed);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Unexpected error uploading object '{Key}' to bucket '{Bucket}'", key, _bucketName);
-            return Result.Failure("Failed to upload file to storage.");
+            return Result.Failure(ErrorMessages.FileStorage.UploadFailed);
         }
     }
 
@@ -76,17 +76,17 @@ internal sealed class S3FileStorageService(
         }
         catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
-            return Result<FileDownloadOutput>.Failure("File not found.", ErrorType.NotFound);
+            return Result<FileDownloadOutput>.Failure(ErrorMessages.FileStorage.NotFound, ErrorType.NotFound);
         }
         catch (AmazonS3Exception ex)
         {
             logger.LogError(ex, "Failed to download object '{Key}' from bucket '{Bucket}'", key, _bucketName);
-            return Result<FileDownloadOutput>.Failure("Failed to retrieve file from storage.");
+            return Result<FileDownloadOutput>.Failure(ErrorMessages.FileStorage.DownloadFailed);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Unexpected error downloading object '{Key}' from bucket '{Bucket}'", key, _bucketName);
-            return Result<FileDownloadOutput>.Failure("Failed to retrieve file from storage.");
+            return Result<FileDownloadOutput>.Failure(ErrorMessages.FileStorage.DownloadFailed);
         }
     }
 
@@ -109,12 +109,12 @@ internal sealed class S3FileStorageService(
         catch (AmazonS3Exception ex)
         {
             logger.LogError(ex, "Failed to delete object '{Key}' from bucket '{Bucket}'", key, _bucketName);
-            return Result.Failure("Failed to delete file from storage.");
+            return Result.Failure(ErrorMessages.FileStorage.DeleteFailed);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Unexpected error deleting object '{Key}' from bucket '{Bucket}'", key, _bucketName);
-            return Result.Failure("Failed to delete file from storage.");
+            return Result.Failure(ErrorMessages.FileStorage.DeleteFailed);
         }
     }
 

--- a/src/backend/MyProject.Infrastructure/Identity/Services/UserService.cs
+++ b/src/backend/MyProject.Infrastructure/Identity/Services/UserService.cs
@@ -384,7 +384,7 @@ internal sealed class UserService(
         {
             logger.LogWarning("DeleteAsync failed for user '{UserId}': {Errors}",
                 user.Id, string.Join(", ", result.Errors.Select(e => e.Description)));
-            throw new InvalidOperationException(ErrorMessages.User.DeleteFailed);
+            throw new InvalidOperationException(ErrorMessages.User.DeleteFailed.Message);
         }
     }
 

--- a/src/backend/MyProject.Infrastructure/Persistence/Extensions/PaginationExtensions.cs
+++ b/src/backend/MyProject.Infrastructure/Persistence/Extensions/PaginationExtensions.cs
@@ -21,11 +21,11 @@ public static class PaginationExtensions
     /// <exception cref="PaginationException">Thrown when page number is less than or equal to 0, or when page size is less than or equal to 0</exception>
     public static IQueryable<T> Paginate<T>(this IQueryable<T> ts, int pageNumber, int pageSize)
     {
-        if (pageNumber <= 0) throw new PaginationException(nameof(pageNumber), ErrorMessages.Pagination.InvalidPage);
+        if (pageNumber <= 0) throw new PaginationException(nameof(pageNumber), ErrorMessages.Pagination.InvalidPage.Message);
 
         pageSize = pageSize switch
         {
-            <= 0 => throw new PaginationException(nameof(pageSize), ErrorMessages.Pagination.InvalidPageSize),
+            <= 0 => throw new PaginationException(nameof(pageSize), ErrorMessages.Pagination.InvalidPageSize.Message),
             > MaxPageSize => MaxPageSize,
             _ => pageSize
         };

--- a/src/backend/MyProject.Shared/Error.cs
+++ b/src/backend/MyProject.Shared/Error.cs
@@ -1,0 +1,22 @@
+namespace MyProject.Shared;
+
+/// <summary>
+/// A client-facing error consisting of a stable, machine-readable <see cref="Code"/> and a
+/// human-readable <see cref="Message"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Instances are declared once in <see cref="ErrorMessages"/> and passed to <c>Result.Failure()</c>.
+/// The code surfaces as the <c>code</c> extension of every <c>ProblemDetails</c> response so that
+/// clients can branch on it (or use it as a translation key) instead of matching English text.
+/// </para>
+/// <para>
+/// Codes are snake_case and derived from the declaring location: <c>{NestedClass}_{FieldName}</c>
+/// (for example <c>ErrorMessages.ExternalAuth.StateExpired</c> is <c>external_auth_state_expired</c>).
+/// Treat codes as a public contract - renaming one is a breaking change for API consumers.
+/// </para>
+/// <para>Pattern documented in .claude/skills/backend-conventions/SKILL.md.</para>
+/// </remarks>
+/// <param name="Code">The stable, snake_case, machine-readable identifier of the error condition.</param>
+/// <param name="Message">The human-readable, client-facing description of the error.</param>
+public sealed record Error(string Code, string Message);

--- a/src/backend/MyProject.Shared/ErrorMessages.cs
+++ b/src/backend/MyProject.Shared/ErrorMessages.cs
@@ -1,13 +1,20 @@
 namespace MyProject.Shared;
 
 /// <summary>
-/// User-facing error messages organized by domain area.
-/// Constants are used in <c>Result.Failure()</c> calls so that messages remain consistent,
-/// greppable, and easy to extract into translation keys later.
+/// User-facing errors organized by domain area. Each entry is an <see cref="Error"/> pairing a stable,
+/// machine-readable code with a human-readable message. Entries are used in <c>Result.Failure()</c> calls
+/// so that messages remain consistent, greppable, and translatable by clients via the code.
 /// <para>
-/// All client-facing messages must be static constants — never interpolate runtime values
+/// Codes follow <c>{nested_class}_{field_name}</c> in snake_case and are verified by
+/// <c>ErrorMessagesTests</c>. Renaming a code is a breaking change for API consumers.
+/// </para>
+/// <para>
+/// All client-facing messages must be static - never interpolate runtime values
 /// (role names, user IDs, framework error descriptions) into error responses.
-/// Log runtime details server-side via <c>ILogger</c> instead.
+/// Log runtime details server-side via <c>ILogger</c> instead. The only exceptions are
+/// entries explicitly documented as carrying a dynamic message (password policy feedback,
+/// rate-limit retry hints); those keep their stable code and override <see cref="Error.Message"/>
+/// with a <c>with</c> expression.
 /// </para>
 /// </summary>
 public static class ErrorMessages
@@ -17,25 +24,37 @@ public static class ErrorMessages
     /// </summary>
     public static class Auth
     {
-        public const string LoginInvalidCredentials = "Invalid username or password.";
-        public const string LoginAccountLocked = "Account is temporarily locked. Please try again later or contact an administrator.";
-        public const string RegisterRoleAssignFailed = "Account was created but role assignment failed. Please contact an administrator.";
-        public const string TokenMissing = "Refresh token is missing.";
-        public const string TokenNotFound = "Refresh token not found.";
-        public const string TokenInvalidated = "Refresh token has been invalidated.";
-        public const string TokenReused = "Invalid refresh token.";
-        public const string TokenExpired = "Refresh token has expired.";
-        public const string TokenUserNotFound = "Token owner not found.";
-        public const string NotAuthenticated = "User is not authenticated.";
-        public const string InsufficientPermissions = "You do not have the required permissions for this action.";
-        public const string UserNotFound = "User not found.";
-        public const string PasswordIncorrect = "Current password is incorrect.";
-        public const string ResetPasswordFailed = "Password reset failed. The link may have expired or already been used.";
-        public const string ResetPasswordTokenInvalid = "Invalid or expired password reset token.";
-        public const string EmailVerificationFailed = "Email verification failed. The link may have expired or already been used.";
-        public const string EmailAlreadyVerified = "Email address is already verified.";
-        public const string PasswordSameAsCurrent = "New password must be different from your current password.";
-        public const string CaptchaInvalid = "CAPTCHA verification failed. Please try again.";
+        public static readonly Error LoginInvalidCredentials = new("auth_login_invalid_credentials", "Invalid username or password.");
+        public static readonly Error LoginAccountLocked = new("auth_login_account_locked", "Account is temporarily locked. Please try again later or contact an administrator.");
+        public static readonly Error RegisterRoleAssignFailed = new("auth_register_role_assign_failed", "Account was created but role assignment failed. Please contact an administrator.");
+        public static readonly Error TokenMissing = new("auth_token_missing", "Refresh token is missing.");
+        public static readonly Error TokenNotFound = new("auth_token_not_found", "Refresh token not found.");
+        public static readonly Error TokenInvalidated = new("auth_token_invalidated", "Refresh token has been invalidated.");
+        public static readonly Error TokenReused = new("auth_token_reused", "Invalid refresh token.");
+        public static readonly Error TokenExpired = new("auth_token_expired", "Refresh token has expired.");
+        public static readonly Error TokenUserNotFound = new("auth_token_user_not_found", "Token owner not found.");
+        public static readonly Error NotAuthenticated = new("auth_not_authenticated", "User is not authenticated.");
+        public static readonly Error InsufficientPermissions = new("auth_insufficient_permissions", "You do not have the required permissions for this action.");
+        public static readonly Error UserNotFound = new("auth_user_not_found", "User not found.");
+        public static readonly Error PasswordIncorrect = new("auth_password_incorrect", "Current password is incorrect.");
+        public static readonly Error ResetPasswordFailed = new("auth_reset_password_failed", "Password reset failed. The link may have expired or already been used.");
+        public static readonly Error ResetPasswordTokenInvalid = new("auth_reset_password_token_invalid", "Invalid or expired password reset token.");
+        public static readonly Error EmailVerificationFailed = new("auth_email_verification_failed", "Email verification failed. The link may have expired or already been used.");
+        public static readonly Error EmailAlreadyVerified = new("auth_email_already_verified", "Email address is already verified.");
+        public static readonly Error PasswordSameAsCurrent = new("auth_password_same_as_current", "New password must be different from your current password.");
+        public static readonly Error CaptchaInvalid = new("auth_captcha_invalid", "CAPTCHA verification failed. Please try again.");
+
+        /// <summary>
+        /// Registration rejected by ASP.NET Identity (password policy, duplicate email). The message is
+        /// overridden with the Identity error descriptions so users get actionable feedback.
+        /// </summary>
+        public static readonly Error RegistrationInvalid = new("auth_registration_invalid", "Registration failed. Please check the provided details.");
+
+        /// <summary>
+        /// New password rejected by the password policy. The message is overridden with the
+        /// Identity error descriptions so users get actionable feedback.
+        /// </summary>
+        public static readonly Error PasswordPolicyViolation = new("auth_password_policy_violation", "The new password does not meet the password requirements.");
     }
 
     /// <summary>
@@ -43,15 +62,15 @@ public static class ErrorMessages
     /// </summary>
     public static class TwoFactor
     {
-        public const string SetupFailed = "Failed to set up two-factor authentication.";
-        public const string VerificationFailed = "The verification code is invalid. Please try again.";
-        public const string AlreadyEnabled = "Two-factor authentication is already enabled.";
-        public const string NotEnabled = "Two-factor authentication is not enabled.";
-        public const string DisableFailed = "Failed to disable two-factor authentication.";
-        public const string ChallengeNotFound = "Two-factor challenge not found or expired.";
-        public const string ChallengeLocked = "Too many failed attempts. Please log in again.";
-        public const string RecoveryCodeInvalid = "The recovery code is invalid.";
-        public const string InvalidCode = "The two-factor code is invalid.";
+        public static readonly Error SetupFailed = new("two_factor_setup_failed", "Failed to set up two-factor authentication.");
+        public static readonly Error VerificationFailed = new("two_factor_verification_failed", "The verification code is invalid. Please try again.");
+        public static readonly Error AlreadyEnabled = new("two_factor_already_enabled", "Two-factor authentication is already enabled.");
+        public static readonly Error NotEnabled = new("two_factor_not_enabled", "Two-factor authentication is not enabled.");
+        public static readonly Error DisableFailed = new("two_factor_disable_failed", "Failed to disable two-factor authentication.");
+        public static readonly Error ChallengeNotFound = new("two_factor_challenge_not_found", "Two-factor challenge not found or expired.");
+        public static readonly Error ChallengeLocked = new("two_factor_challenge_locked", "Too many failed attempts. Please log in again.");
+        public static readonly Error RecoveryCodeInvalid = new("two_factor_recovery_code_invalid", "The recovery code is invalid.");
+        public static readonly Error InvalidCode = new("two_factor_invalid_code", "The two-factor code is invalid.");
     }
 
     /// <summary>
@@ -59,13 +78,13 @@ public static class ErrorMessages
     /// </summary>
     public static class User
     {
-        public const string NotAuthenticated = "User is not authenticated.";
-        public const string NotFound = "User not found.";
-        public const string DeleteInvalidPassword = "Invalid password.";
-        public const string PhoneNumberTaken = "This phone number is already in use.";
-        public const string UpdateFailed = "Failed to update profile.";
-        public const string DeleteFailed = "Failed to delete account.";
-        public const string LastSuperuserCannotDelete = "Cannot delete your account while you are the last superuser.";
+        public static readonly Error NotAuthenticated = new("user_not_authenticated", "User is not authenticated.");
+        public static readonly Error NotFound = new("user_not_found", "User not found.");
+        public static readonly Error DeleteInvalidPassword = new("user_delete_invalid_password", "Invalid password.");
+        public static readonly Error PhoneNumberTaken = new("user_phone_number_taken", "This phone number is already in use.");
+        public static readonly Error UpdateFailed = new("user_update_failed", "Failed to update profile.");
+        public static readonly Error DeleteFailed = new("user_delete_failed", "Failed to delete account.");
+        public static readonly Error LastSuperuserCannotDelete = new("user_last_superuser_cannot_delete", "Cannot delete your account while you are the last superuser.");
     }
 
     /// <summary>
@@ -73,31 +92,31 @@ public static class ErrorMessages
     /// </summary>
     public static class Admin
     {
-        public const string UserNotFound = "User not found.";
-        public const string HierarchyInsufficient = "You do not have sufficient privileges to manage this user.";
-        public const string RoleAssignAboveRank = "Cannot assign a role at or above your own rank.";
-        public const string RoleRemoveAboveRank = "Cannot remove a role at or above your own rank.";
-        public const string RoleSelfRemove = "Cannot remove a role from your own account.";
-        public const string LockSelfAction = "Cannot lock your own account.";
-        public const string DeleteSelfAction = "Cannot delete your own account.";
-        public const string EmailVerificationRequired = "User must have a verified email address before being assigned this role.";
-        public const string EmailAlreadyRegistered = "A user with this email address already exists.";
-        public const string RoleAssignEscalation = "Cannot assign a role that grants permissions you do not hold.";
-        public const string RoleNotFound = "Role not found.";
-        public const string RoleAlreadyAssigned = "User already has this role.";
-        public const string RoleNotAssigned = "User does not have this role.";
-        public const string LastRoleHolder = "Cannot remove this role - this is the last user holding it.";
-        public const string RoleAssignFailed = "Failed to assign role.";
-        public const string RoleRemoveFailed = "Failed to remove role.";
-        public const string LockFailed = "Failed to lock user account.";
-        public const string UnlockFailed = "Failed to unlock user account.";
-        public const string DeleteFailed = "Failed to delete user account.";
-        public const string EmailVerificationFailed = "Failed to verify email address.";
-        public const string CreateUserFailed = "Failed to create user account.";
-        public const string LastSuperuserCannotDelete = "Cannot delete this user - they are the last superuser.";
-        public const string TwoFactorNotEnabled = "Two-factor authentication is not enabled for this user.";
-        public const string DisableTwoFactorSelfAction = "You cannot disable your own two-factor authentication from the admin panel.";
-        public const string DisableTwoFactorFailed = "Failed to disable two-factor authentication.";
+        public static readonly Error UserNotFound = new("admin_user_not_found", "User not found.");
+        public static readonly Error HierarchyInsufficient = new("admin_hierarchy_insufficient", "You do not have sufficient privileges to manage this user.");
+        public static readonly Error RoleAssignAboveRank = new("admin_role_assign_above_rank", "Cannot assign a role at or above your own rank.");
+        public static readonly Error RoleRemoveAboveRank = new("admin_role_remove_above_rank", "Cannot remove a role at or above your own rank.");
+        public static readonly Error RoleSelfRemove = new("admin_role_self_remove", "Cannot remove a role from your own account.");
+        public static readonly Error LockSelfAction = new("admin_lock_self_action", "Cannot lock your own account.");
+        public static readonly Error DeleteSelfAction = new("admin_delete_self_action", "Cannot delete your own account.");
+        public static readonly Error EmailVerificationRequired = new("admin_email_verification_required", "User must have a verified email address before being assigned this role.");
+        public static readonly Error EmailAlreadyRegistered = new("admin_email_already_registered", "A user with this email address already exists.");
+        public static readonly Error RoleAssignEscalation = new("admin_role_assign_escalation", "Cannot assign a role that grants permissions you do not hold.");
+        public static readonly Error RoleNotFound = new("admin_role_not_found", "Role not found.");
+        public static readonly Error RoleAlreadyAssigned = new("admin_role_already_assigned", "User already has this role.");
+        public static readonly Error RoleNotAssigned = new("admin_role_not_assigned", "User does not have this role.");
+        public static readonly Error LastRoleHolder = new("admin_last_role_holder", "Cannot remove this role - this is the last user holding it.");
+        public static readonly Error RoleAssignFailed = new("admin_role_assign_failed", "Failed to assign role.");
+        public static readonly Error RoleRemoveFailed = new("admin_role_remove_failed", "Failed to remove role.");
+        public static readonly Error LockFailed = new("admin_lock_failed", "Failed to lock user account.");
+        public static readonly Error UnlockFailed = new("admin_unlock_failed", "Failed to unlock user account.");
+        public static readonly Error DeleteFailed = new("admin_delete_failed", "Failed to delete user account.");
+        public static readonly Error EmailVerificationFailed = new("admin_email_verification_failed", "Failed to verify email address.");
+        public static readonly Error CreateUserFailed = new("admin_create_user_failed", "Failed to create user account.");
+        public static readonly Error LastSuperuserCannotDelete = new("admin_last_superuser_cannot_delete", "Cannot delete this user - they are the last superuser.");
+        public static readonly Error TwoFactorNotEnabled = new("admin_two_factor_not_enabled", "Two-factor authentication is not enabled for this user.");
+        public static readonly Error DisableTwoFactorSelfAction = new("admin_disable_two_factor_self_action", "You cannot disable your own two-factor authentication from the admin panel.");
+        public static readonly Error DisableTwoFactorFailed = new("admin_disable_two_factor_failed", "Failed to disable two-factor authentication.");
     }
 
     /// <summary>
@@ -105,18 +124,18 @@ public static class ErrorMessages
     /// </summary>
     public static class Roles
     {
-        public const string SystemRoleCannotBeDeleted = "System roles cannot be deleted.";
-        public const string SystemRoleCannotBeRenamed = "System roles cannot be renamed.";
-        public const string RoleNotFound = "Role not found.";
-        public const string RoleNameTaken = "A role with this name already exists.";
-        public const string RoleHasUsers = "Cannot delete a role that has users assigned to it.";
-        public const string InvalidPermission = "One or more permission values are invalid.";
-        public const string SystemRoleNameReserved = "This name is reserved for a system role.";
-        public const string SuperuserPermissionsFixed = "Superuser permissions cannot be modified.";
-        public const string CannotGrantUnheldPermission = "Cannot grant permissions that you do not hold.";
-        public const string CreateFailed = "Failed to create role.";
-        public const string UpdateFailed = "Failed to update role.";
-        public const string DeleteFailed = "Failed to delete role.";
+        public static readonly Error SystemRoleCannotBeDeleted = new("roles_system_role_cannot_be_deleted", "System roles cannot be deleted.");
+        public static readonly Error SystemRoleCannotBeRenamed = new("roles_system_role_cannot_be_renamed", "System roles cannot be renamed.");
+        public static readonly Error RoleNotFound = new("roles_role_not_found", "Role not found.");
+        public static readonly Error RoleNameTaken = new("roles_role_name_taken", "A role with this name already exists.");
+        public static readonly Error RoleHasUsers = new("roles_role_has_users", "Cannot delete a role that has users assigned to it.");
+        public static readonly Error InvalidPermission = new("roles_invalid_permission", "One or more permission values are invalid.");
+        public static readonly Error SystemRoleNameReserved = new("roles_system_role_name_reserved", "This name is reserved for a system role.");
+        public static readonly Error SuperuserPermissionsFixed = new("roles_superuser_permissions_fixed", "Superuser permissions cannot be modified.");
+        public static readonly Error CannotGrantUnheldPermission = new("roles_cannot_grant_unheld_permission", "Cannot grant permissions that you do not hold.");
+        public static readonly Error CreateFailed = new("roles_create_failed", "Failed to create role.");
+        public static readonly Error UpdateFailed = new("roles_update_failed", "Failed to update role.");
+        public static readonly Error DeleteFailed = new("roles_delete_failed", "Failed to delete role.");
     }
 
     /// <summary>
@@ -124,8 +143,8 @@ public static class ErrorMessages
     /// </summary>
     public static class Pagination
     {
-        public const string InvalidPage = "Page number must be positive.";
-        public const string InvalidPageSize = "Page size must be positive.";
+        public static readonly Error InvalidPage = new("pagination_invalid_page", "Page number must be positive.");
+        public static readonly Error InvalidPageSize = new("pagination_invalid_page_size", "Page size must be positive.");
     }
 
     /// <summary>
@@ -133,7 +152,13 @@ public static class ErrorMessages
     /// </summary>
     public static class Server
     {
-        public const string InternalError = "An internal error occurred.";
+        public static readonly Error InternalError = new("server_internal_error", "An internal error occurred.");
+
+        /// <summary>
+        /// Request rejected by the rate limiter. The message is overridden with the retry hint
+        /// (seconds until the window resets).
+        /// </summary>
+        public static readonly Error TooManyRequests = new("server_too_many_requests", "Too many requests. Please try again later.");
     }
 
     /// <summary>
@@ -141,9 +166,9 @@ public static class ErrorMessages
     /// </summary>
     public static class Jobs
     {
-        public const string NotFound = "Job not found.";
-        public const string TriggerFailed = "Failed to trigger job.";
-        public const string RestoreFailed = "Failed to restore jobs.";
+        public static readonly Error NotFound = new("jobs_not_found", "Job not found.");
+        public static readonly Error TriggerFailed = new("jobs_trigger_failed", "Failed to trigger job.");
+        public static readonly Error RestoreFailed = new("jobs_restore_failed", "Failed to restore jobs.");
     }
 
     /// <summary>
@@ -151,7 +176,7 @@ public static class ErrorMessages
     /// </summary>
     public static class Security
     {
-        public const string CrossOriginRequestBlocked = "Cross-origin requests are not allowed.";
+        public static readonly Error CrossOriginRequestBlocked = new("security_cross_origin_request_blocked", "Cross-origin requests are not allowed.");
     }
 
     /// <summary>
@@ -159,10 +184,21 @@ public static class ErrorMessages
     /// </summary>
     public static class Avatar
     {
-        public const string FileTooLarge = "The file exceeds the maximum allowed size of 5 MB.";
-        public const string UnsupportedFormat = "Unsupported image format. Allowed formats: JPEG, PNG, WebP, GIF.";
-        public const string ProcessingFailed = "Failed to process the avatar image.";
-        public const string NotFound = "Avatar not found.";
+        public static readonly Error FileTooLarge = new("avatar_file_too_large", "The file exceeds the maximum allowed size of 5 MB.");
+        public static readonly Error UnsupportedFormat = new("avatar_unsupported_format", "Unsupported image format. Allowed formats: JPEG, PNG, WebP, GIF.");
+        public static readonly Error ProcessingFailed = new("avatar_processing_failed", "Failed to process the avatar image.");
+        public static readonly Error NotFound = new("avatar_not_found", "Avatar not found.");
+    }
+
+    /// <summary>
+    /// File storage (S3-compatible) error messages.
+    /// </summary>
+    public static class FileStorage
+    {
+        public static readonly Error UploadFailed = new("file_storage_upload_failed", "Failed to upload file to storage.");
+        public static readonly Error DownloadFailed = new("file_storage_download_failed", "Failed to retrieve file from storage.");
+        public static readonly Error DeleteFailed = new("file_storage_delete_failed", "Failed to delete file from storage.");
+        public static readonly Error NotFound = new("file_storage_not_found", "File not found.");
     }
 
     /// <summary>
@@ -170,23 +206,23 @@ public static class ErrorMessages
     /// </summary>
     public static class ExternalAuth
     {
-        public const string ProviderNotConfigured = "The requested authentication provider is not configured.";
-        public const string InvalidState = "Invalid or missing OAuth state token.";
-        public const string StateExpired = "OAuth state token has expired. Please try again.";
-        public const string EmailNotVerified = "Your email address must be verified before linking an external account. Please verify your email first.";
-        public const string AlreadyLinkedToOtherUser = "This external account is already linked to another user.";
-        public const string ProviderNotLinked = "This provider is not linked to your account.";
-        public const string CannotUnlinkLastMethod = "Cannot unlink this provider because it is your only sign-in method. Set a password first.";
-        public const string CodeExchangeFailed = "Failed to exchange the authorization code with the provider.";
-        public const string ProviderError = "The external authentication provider returned an error.";
-        public const string InvalidRedirectUri = "The provided redirect URI is not allowed.";
-        public const string PasswordAlreadySet = "A password is already set for this account.";
-        public const string PasswordSetFailed = "Failed to set the password. Please try again.";
-        public const string UnknownProvider = "The specified authentication provider is not recognized.";
-        public const string ClientSecretRequired = "A client secret is required when enabling a provider that has no existing secret.";
-        public const string TestConnectionInvalidCredentials = "The provider rejected the credentials. Verify the client ID and secret are correct.";
-        public const string TestConnectionProviderUnreachable = "Could not reach the authentication provider. Please try again later.";
-        public const string TestConnectionNotConfigured = "No credentials are configured for this provider.";
+        public static readonly Error ProviderNotConfigured = new("external_auth_provider_not_configured", "The requested authentication provider is not configured.");
+        public static readonly Error InvalidState = new("external_auth_invalid_state", "Invalid or missing OAuth state token.");
+        public static readonly Error StateExpired = new("external_auth_state_expired", "OAuth state token has expired. Please try again.");
+        public static readonly Error EmailNotVerified = new("external_auth_email_not_verified", "Your email address must be verified before linking an external account. Please verify your email first.");
+        public static readonly Error AlreadyLinkedToOtherUser = new("external_auth_already_linked_to_other_user", "This external account is already linked to another user.");
+        public static readonly Error ProviderNotLinked = new("external_auth_provider_not_linked", "This provider is not linked to your account.");
+        public static readonly Error CannotUnlinkLastMethod = new("external_auth_cannot_unlink_last_method", "Cannot unlink this provider because it is your only sign-in method. Set a password first.");
+        public static readonly Error CodeExchangeFailed = new("external_auth_code_exchange_failed", "Failed to exchange the authorization code with the provider.");
+        public static readonly Error ProviderError = new("external_auth_provider_error", "The external authentication provider returned an error.");
+        public static readonly Error InvalidRedirectUri = new("external_auth_invalid_redirect_uri", "The provided redirect URI is not allowed.");
+        public static readonly Error PasswordAlreadySet = new("external_auth_password_already_set", "A password is already set for this account.");
+        public static readonly Error PasswordSetFailed = new("external_auth_password_set_failed", "Failed to set the password. Please try again.");
+        public static readonly Error UnknownProvider = new("external_auth_unknown_provider", "The specified authentication provider is not recognized.");
+        public static readonly Error ClientSecretRequired = new("external_auth_client_secret_required", "A client secret is required when enabling a provider that has no existing secret.");
+        public static readonly Error TestConnectionInvalidCredentials = new("external_auth_test_connection_invalid_credentials", "The provider rejected the credentials. Verify the client ID and secret are correct.");
+        public static readonly Error TestConnectionProviderUnreachable = new("external_auth_test_connection_provider_unreachable", "Could not reach the authentication provider. Please try again later.");
+        public static readonly Error TestConnectionNotConfigured = new("external_auth_test_connection_not_configured", "No credentials are configured for this provider.");
     }
 
     /// <summary>
@@ -194,8 +230,8 @@ public static class ErrorMessages
     /// </summary>
     public static class Entity
     {
-        public const string AddFailed = "Failed to add entity.";
-        public const string NotFound = "Entity not found.";
-        public const string NotDeleted = "Entity could not be deleted.";
+        public static readonly Error AddFailed = new("entity_add_failed", "Failed to add entity.");
+        public static readonly Error NotFound = new("entity_not_found", "Entity not found.");
+        public static readonly Error NotDeleted = new("entity_not_deleted", "Entity could not be deleted.");
     }
 }

--- a/src/backend/MyProject.Shared/Result.cs
+++ b/src/backend/MyProject.Shared/Result.cs
@@ -17,9 +17,9 @@ public class Result
     public bool IsFailure => !IsSuccess;
 
     /// <summary>
-    /// Gets the error message if the operation failed.
+    /// Gets the error (machine-readable code plus human-readable message) if the operation failed.
     /// </summary>
-    public string? Error { get; }
+    public Error? Error { get; }
 
     /// <summary>
     /// Gets the error category for the failure, or <c>null</c> when not specified (defaults to 400).
@@ -30,7 +30,7 @@ public class Result
     /// <summary>
     /// Initializes a new instance of the <see cref="Result"/> class.
     /// </summary>
-    protected Result(bool isSuccess, string? error = null, ErrorType? errorType = null)
+    protected Result(bool isSuccess, Error? error = null, ErrorType? errorType = null)
     {
         IsSuccess = isSuccess;
         Error = error;
@@ -47,23 +47,23 @@ public class Result
     }
 
     /// <summary>
-    /// Creates a failed result with the specified error message.
+    /// Creates a failed result with the specified error.
     /// Defaults to 400 (Validation) at the controller layer.
     /// </summary>
-    /// <param name="error">The error message.</param>
-    /// <returns>A failed result containing the error message.</returns>
-    public static Result Failure(string error)
+    /// <param name="error">The error, typically an <see cref="ErrorMessages"/> entry.</param>
+    /// <returns>A failed result containing the error.</returns>
+    public static Result Failure(Error error)
     {
         return new Result(false, error, Shared.ErrorType.Validation);
     }
 
     /// <summary>
-    /// Creates a failed result with the specified error message and error category.
+    /// Creates a failed result with the specified error and error category.
     /// </summary>
-    /// <param name="error">The error message.</param>
+    /// <param name="error">The error, typically an <see cref="ErrorMessages"/> entry.</param>
     /// <param name="errorType">The error category for HTTP status code mapping.</param>
-    /// <returns>A failed result containing the error message and error type.</returns>
-    public static Result Failure(string error, ErrorType errorType)
+    /// <returns>A failed result containing the error and error type.</returns>
+    public static Result Failure(Error error, ErrorType errorType)
     {
         return new Result(false, error, errorType);
     }
@@ -88,7 +88,7 @@ public class Result<T> : Result
         ? _value!
         : throw new InvalidOperationException("Cannot access Value on a failed result.");
 
-    private Result(bool isSuccess, string? error, T? value, ErrorType? errorType = null)
+    private Result(bool isSuccess, Error? error, T? value, ErrorType? errorType = null)
         : base(isSuccess, error, errorType)
     {
         _value = value;
@@ -105,23 +105,23 @@ public class Result<T> : Result
     }
 
     /// <summary>
-    /// Creates a failed result with the specified error message.
+    /// Creates a failed result with the specified error.
     /// Defaults to 400 (Validation) at the controller layer.
     /// </summary>
-    /// <param name="error">The error message.</param>
-    /// <returns>A failed result containing the error message.</returns>
-    public new static Result<T> Failure(string error)
+    /// <param name="error">The error, typically an <see cref="ErrorMessages"/> entry.</param>
+    /// <returns>A failed result containing the error.</returns>
+    public new static Result<T> Failure(Error error)
     {
         return new Result<T>(false, error, default, Shared.ErrorType.Validation);
     }
 
     /// <summary>
-    /// Creates a failed result with the specified error message and error category.
+    /// Creates a failed result with the specified error and error category.
     /// </summary>
-    /// <param name="error">The error message.</param>
+    /// <param name="error">The error, typically an <see cref="ErrorMessages"/> entry.</param>
     /// <param name="errorType">The error category for HTTP status code mapping.</param>
-    /// <returns>A failed result containing the error message and error type.</returns>
-    public new static Result<T> Failure(string error, ErrorType errorType)
+    /// <returns>A failed result containing the error and error type.</returns>
+    public new static Result<T> Failure(Error error, ErrorType errorType)
     {
         return new Result<T>(false, error, default, errorType);
     }

--- a/src/backend/MyProject.WebApi/Authorization/ProblemDetailsAuthorizationHandler.cs
+++ b/src/backend/MyProject.WebApi/Authorization/ProblemDetailsAuthorizationHandler.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Mvc;
 using MyProject.Shared;
+using MyProject.WebApi.Shared;
 
 namespace MyProject.WebApi.Authorization;
 
@@ -28,11 +29,8 @@ internal sealed class ProblemDetailsAuthorizationHandler(
             await problemDetailsService.WriteAsync(new ProblemDetailsContext
             {
                 HttpContext = httpContext,
-                ProblemDetails = new ProblemDetails
-                {
-                    Status = StatusCodes.Status401Unauthorized,
-                    Detail = ErrorMessages.Auth.NotAuthenticated
-                }
+                ProblemDetails = ProblemFactory.CreateProblemDetails(
+                    ErrorMessages.Auth.NotAuthenticated, StatusCodes.Status401Unauthorized)
             });
             return;
         }
@@ -44,11 +42,8 @@ internal sealed class ProblemDetailsAuthorizationHandler(
             await problemDetailsService.WriteAsync(new ProblemDetailsContext
             {
                 HttpContext = httpContext,
-                ProblemDetails = new ProblemDetails
-                {
-                    Status = StatusCodes.Status403Forbidden,
-                    Detail = ErrorMessages.Auth.InsufficientPermissions
-                }
+                ProblemDetails = ProblemFactory.CreateProblemDetails(
+                    ErrorMessages.Auth.InsufficientPermissions, StatusCodes.Status403Forbidden)
             });
             return;
         }

--- a/src/backend/MyProject.WebApi/Extensions/RateLimiterExtensions.cs
+++ b/src/backend/MyProject.WebApi/Extensions/RateLimiterExtensions.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using MyProject.Shared;
 using MyProject.WebApi.Options;
 using MyProject.WebApi.Shared;
 
@@ -92,15 +93,15 @@ internal static class RateLimiterExtensions
             context.HttpContext.Response.Headers.RetryAfter = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
 
             var problemDetailsService = context.HttpContext.RequestServices.GetRequiredService<IProblemDetailsService>();
+            var error = ErrorMessages.Server.TooManyRequests with
+            {
+                Message = $"Too many requests. Please try again in {retryAfterSeconds} seconds."
+            };
+
             await problemDetailsService.WriteAsync(new ProblemDetailsContext
             {
                 HttpContext = context.HttpContext,
-                ProblemDetails = new ProblemDetails
-                {
-                    Status = StatusCodes.Status429TooManyRequests,
-                    Title = "Too Many Requests",
-                    Detail = $"Too many requests. Please try again in {retryAfterSeconds} seconds."
-                }
+                ProblemDetails = ProblemFactory.CreateProblemDetails(error, StatusCodes.Status429TooManyRequests)
             });
         };
     }

--- a/src/backend/MyProject.WebApi/Features/OpenApi/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/backend/MyProject.WebApi/Features/OpenApi/Extensions/WebApplicationBuilderExtensions.cs
@@ -23,6 +23,7 @@ internal static class WebApplicationBuilderExtensions
             opt.AddOperationTransformer<CamelCaseQueryParameterTransformer>();
             opt.AddSchemaTransformer<EnumSchemaTransformer>();
             opt.AddSchemaTransformer<NumericSchemaTransformer>();
+            opt.AddSchemaTransformer<ProblemDetailsSchemaTransformer>();
         });
 
         return builder;

--- a/src/backend/MyProject.WebApi/Features/OpenApi/Transformers/ProblemDetailsSchemaTransformer.cs
+++ b/src/backend/MyProject.WebApi/Features/OpenApi/Transformers/ProblemDetailsSchemaTransformer.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+using MyProject.WebApi.Shared;
+
+namespace MyProject.WebApi.Features.OpenApi.Transformers;
+
+/// <summary>
+/// Documents the <c>code</c> extension on every <see cref="ProblemDetails"/>-derived schema.
+/// The extension is written at runtime via <c>ProblemDetails.Extensions</c>, which the schema
+/// generator cannot see, so it is declared here to keep generated clients (frontend <c>v1.d.ts</c>) accurate.
+/// </summary>
+/// <remarks>See .claude/skills/backend-conventions/SKILL.md for the error code convention.</remarks>
+internal sealed class ProblemDetailsSchemaTransformer : IOpenApiSchemaTransformer
+{
+    /// <inheritdoc />
+    public Task TransformAsync(
+        OpenApiSchema schema,
+        OpenApiSchemaTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!typeof(ProblemDetails).IsAssignableFrom(context.JsonTypeInfo.Type))
+        {
+            return Task.CompletedTask;
+        }
+
+        schema.Properties ??= new Dictionary<string, IOpenApiSchema>();
+        schema.Properties[ProblemFactory.CodeExtensionKey] = new OpenApiSchema
+        {
+            Type = JsonSchemaType.String,
+            Description = "Stable, machine-readable error code (snake_case). Use it to branch on the error " +
+                          "or as a translation key instead of matching the human-readable detail."
+        };
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/backend/MyProject.WebApi/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/src/backend/MyProject.WebApi/Middlewares/ExceptionHandlingMiddleware.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using MyProject.Infrastructure.Persistence.Exceptions;
 using MyProject.Shared;
+using MyProject.WebApi.Shared;
 
 namespace MyProject.WebApi.Middlewares;
 
@@ -31,13 +32,13 @@ public class ExceptionHandlingMiddleware(
         {
             logger.LogWarning(keyNotFoundEx, "A KeyNotFoundException occurred.");
             await HandleExceptionAsync(context, keyNotFoundEx, HttpStatusCode.NotFound,
-                customMessage: ErrorMessages.Entity.NotFound);
+                ErrorMessages.Entity.NotFound);
         }
         catch (PaginationException paginationEx)
         {
             logger.LogWarning(paginationEx, "A PaginationException occurred.");
             await HandleExceptionAsync(context, paginationEx, HttpStatusCode.BadRequest,
-                customMessage: paginationEx.ParamName is "pageSize"
+                paginationEx.ParamName is "pageSize"
                     ? ErrorMessages.Pagination.InvalidPageSize
                     : ErrorMessages.Pagination.InvalidPage);
         }
@@ -45,7 +46,7 @@ public class ExceptionHandlingMiddleware(
         {
             logger.LogError(e, "An unhandled exception occurred.");
             await HandleExceptionAsync(context, e, HttpStatusCode.InternalServerError,
-                customMessage: ErrorMessages.Server.InternalError);
+                ErrorMessages.Server.InternalError);
         }
     }
 
@@ -53,16 +54,12 @@ public class ExceptionHandlingMiddleware(
         HttpContext context,
         Exception exception,
         HttpStatusCode statusCode,
-        string? customMessage = null)
+        Error error)
     {
         var status = (int)statusCode;
         context.Response.StatusCode = status;
 
-        var problemDetails = new ProblemDetails
-        {
-            Status = status,
-            Detail = customMessage ?? ErrorMessages.Server.InternalError
-        };
+        var problemDetails = ProblemFactory.CreateProblemDetails(error, status);
 
         if (env.IsDevelopment() && exception.StackTrace is not null)
         {

--- a/src/backend/MyProject.WebApi/Middlewares/OriginValidationMiddleware.cs
+++ b/src/backend/MyProject.WebApi/Middlewares/OriginValidationMiddleware.cs
@@ -1,6 +1,6 @@
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using MyProject.Shared;
+using MyProject.WebApi.Shared;
 using CorsOptions = MyProject.WebApi.Options.CorsOptions;
 
 namespace MyProject.WebApi.Middlewares;
@@ -74,11 +74,8 @@ public class OriginValidationMiddleware(
         await problemDetailsService.WriteAsync(new ProblemDetailsContext
         {
             HttpContext = context,
-            ProblemDetails = new ProblemDetails
-            {
-                Status = StatusCodes.Status403Forbidden,
-                Detail = ErrorMessages.Security.CrossOriginRequestBlocked
-            }
+            ProblemDetails = ProblemFactory.CreateProblemDetails(
+                ErrorMessages.Security.CrossOriginRequestBlocked, StatusCodes.Status403Forbidden)
         });
     }
 }

--- a/src/backend/MyProject.WebApi/Program.cs
+++ b/src/backend/MyProject.WebApi/Program.cs
@@ -18,6 +18,7 @@ using MyProject.WebApi.Extensions;
 using MyProject.WebApi.Features.OpenApi.Extensions;
 using MyProject.WebApi.Middlewares;
 using MyProject.WebApi.Routing;
+using MyProject.WebApi.Shared;
 using Serilog;
 using LoggerConfigurationExtensions = MyProject.Infrastructure.Logging.Extensions.LoggerConfigurationExtensions;
 
@@ -109,6 +110,7 @@ try
         options.CustomizeProblemDetails = context =>
         {
             context.ProblemDetails.Instance = context.HttpContext.Request.Path;
+            ProblemFactory.EnsureCode(context.ProblemDetails);
         };
     });
 

--- a/src/backend/MyProject.WebApi/Shared/ProblemFactory.cs
+++ b/src/backend/MyProject.WebApi/Shared/ProblemFactory.cs
@@ -5,30 +5,90 @@ using MyProject.Shared;
 namespace MyProject.WebApi.Shared;
 
 /// <summary>
-/// Creates <see cref="ProblemDetails"/>-based action results from atomic error values.
-/// Produces a consistent <see cref="ProblemDetails"/> body with Title set from the
-/// status code's reason phrase.
+/// Creates <see cref="ProblemDetails"/> bodies and action results from <see cref="Error"/> values.
+/// Every body carries the human-readable message in <c>detail</c> and the stable, machine-readable
+/// error code in the <c>code</c> extension so clients never have to match on English text.
 /// </summary>
 internal static class ProblemFactory
 {
     /// <summary>
-    /// Returns a <see cref="ProblemDetails"/> response with the specified detail and error type.
+    /// Name of the <see cref="ProblemDetails.Extensions"/> entry that carries the machine-readable error code.
     /// </summary>
-    /// <param name="detail">The error detail message.</param>
+    public const string CodeExtensionKey = "code";
+
+    /// <summary>
+    /// Code applied to framework-generated validation failures (<see cref="HttpValidationProblemDetails"/>),
+    /// whose field-level details live in <c>errors</c>.
+    /// </summary>
+    public const string ValidationFailedCode = "validation_failed";
+
+    /// <summary>
+    /// Returns a <see cref="ProblemDetails"/> action result for the specified error and error type.
+    /// </summary>
+    /// <param name="error">The error to report. Null is tolerated for defensive call sites and yields no detail or code.</param>
     /// <param name="errorType">The error category. Defaults to 400 Bad Request when <c>null</c>.</param>
-    public static ObjectResult Create(string? detail, ErrorType? errorType = null)
+    public static ObjectResult Create(Error? error, ErrorType? errorType = null)
     {
-        var code = ToStatusCode(errorType);
+        var statusCode = ToStatusCode(errorType);
 
         var problemDetails = new ProblemDetails
         {
-            Status = code,
-            Detail = detail,
-            Title = ReasonPhrases.GetReasonPhrase(code),
-            Type = $"https://tools.ietf.org/html/rfc9110#section-15.5.{code - 399}"
+            Status = statusCode,
+            Title = ReasonPhrases.GetReasonPhrase(statusCode),
+            Type = $"https://tools.ietf.org/html/rfc9110#section-15.5.{statusCode - 399}"
         };
 
-        return new ObjectResult(problemDetails) { StatusCode = code };
+        if (error is not null)
+        {
+            problemDetails.Detail = error.Message;
+            problemDetails.Extensions[CodeExtensionKey] = error.Code;
+        }
+
+        return new ObjectResult(problemDetails) { StatusCode = statusCode };
+    }
+
+    /// <summary>
+    /// Creates a bare <see cref="ProblemDetails"/> body (status, detail, code) for middleware and handlers
+    /// that write through <see cref="IProblemDetailsService"/>, which fills in title and type defaults.
+    /// </summary>
+    /// <param name="error">The error to report.</param>
+    /// <param name="statusCode">The HTTP status code of the response.</param>
+    public static ProblemDetails CreateProblemDetails(Error error, int statusCode)
+    {
+        return new ProblemDetails
+        {
+            Status = statusCode,
+            Detail = error.Message,
+            Extensions = { [CodeExtensionKey] = error.Code }
+        };
+    }
+
+    /// <summary>
+    /// Ensures a <c>code</c> extension is present on framework-generated problem details
+    /// (model validation, status code pages, unmatched routes). Bodies that already carry a code are left untouched.
+    /// Validation failures get <see cref="ValidationFailedCode"/>; everything else falls back to the
+    /// snake_case reason phrase of the status (for example <c>not_found</c>, <c>method_not_allowed</c>).
+    /// </summary>
+    /// <param name="problemDetails">The problem details being written.</param>
+    public static void EnsureCode(ProblemDetails problemDetails)
+    {
+        if (problemDetails.Extensions.ContainsKey(CodeExtensionKey))
+        {
+            return;
+        }
+
+        problemDetails.Extensions[CodeExtensionKey] = problemDetails is HttpValidationProblemDetails
+            ? ValidationFailedCode
+            : ToFallbackCode(problemDetails.Status ?? StatusCodes.Status500InternalServerError);
+    }
+
+    private static string ToFallbackCode(int statusCode)
+    {
+        var reasonPhrase = ReasonPhrases.GetReasonPhrase(statusCode);
+
+        return string.IsNullOrEmpty(reasonPhrase)
+            ? $"http_{statusCode}"
+            : reasonPhrase.Replace(' ', '_').Replace('-', '_').ToLowerInvariant();
     }
 
     private static int ToStatusCode(ErrorType? errorType) => errorType switch

--- a/src/backend/tests/MyProject.Api.Tests/Controllers/AdminControllerDisableTwoFactorTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Controllers/AdminControllerDisableTwoFactorTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using MyProject.Api.Tests.Fixtures;
 using MyProject.Application.Identity.Constants;
 using MyProject.Shared;
@@ -28,16 +27,6 @@ public class AdminControllerDisableTwoFactorTests : IClassFixture<CustomWebAppli
         return request;
     }
 
-    private static async Task AssertProblemDetailsAsync(
-        HttpResponseMessage response, int expectedStatus, string? expectedDetail = null)
-    {
-        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(expectedStatus, json.GetProperty("status").GetInt32());
-        if (expectedDetail is not null)
-        {
-            Assert.Equal(expectedDetail, json.GetProperty("detail").GetString());
-        }
-    }
 
     [Fact]
     public async Task DisableTwoFactor_WithPermission_Returns204()
@@ -92,7 +81,7 @@ public class AdminControllerDisableTwoFactorTests : IClassFixture<CustomWebAppli
                 JsonContent.Create(new { Reason = (string?)null })));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 404, ErrorMessages.Admin.UserNotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Admin.UserNotFound);
     }
 
     [Fact]
@@ -109,7 +98,7 @@ public class AdminControllerDisableTwoFactorTests : IClassFixture<CustomWebAppli
                 JsonContent.Create(new { Reason = (string?)null })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Admin.TwoFactorNotEnabled);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Admin.TwoFactorNotEnabled);
     }
 
     [Fact]

--- a/src/backend/tests/MyProject.Api.Tests/Controllers/AdminControllerTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Controllers/AdminControllerTests.cs
@@ -52,16 +52,6 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
         return request;
     }
 
-    private static async Task AssertProblemDetailsAsync(
-        HttpResponseMessage response, int expectedStatus, string? expectedDetail = null)
-    {
-        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(expectedStatus, json.GetProperty("status").GetInt32());
-        if (expectedDetail is not null)
-        {
-            Assert.Equal(expectedDetail, json.GetProperty("detail").GetString());
-        }
-    }
 
     #region ListUsers
 
@@ -155,7 +145,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Get($"/api/v1/admin/users/{userId}", TestAuth.WithPermissions(AppPermissions.Users.View)));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 404, ErrorMessages.Admin.UserNotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Admin.UserNotFound);
     }
 
     [Fact]
@@ -331,7 +321,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
                 JsonContent.Create(new { Role = "Admin" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Admin.RoleAssignAboveRank);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Admin.RoleAssignAboveRank);
     }
 
     [Fact]
@@ -348,7 +338,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
                 JsonContent.Create(new { Role = "PrivilegedRole" })));
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 403, ErrorMessages.Admin.RoleAssignEscalation);
+        await ProblemDetailsAssert.MatchesAsync(response, 403, ErrorMessages.Admin.RoleAssignEscalation);
     }
 
     [Fact]
@@ -365,7 +355,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
                 JsonContent.Create(new { Role = "User" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Admin.EmailVerificationRequired);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Admin.EmailVerificationRequired);
     }
 
     #endregion
@@ -467,7 +457,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Delete($"/api/v1/admin/users/{userId}", TestAuth.WithPermissions(AppPermissions.Users.Manage)));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 404, ErrorMessages.Admin.UserNotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Admin.UserNotFound);
     }
 
     [Fact]
@@ -516,7 +506,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Post($"/api/v1/admin/users/{userId}/verify-email", TestAuth.WithPermissions(AppPermissions.Users.Manage)));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 404, ErrorMessages.Admin.UserNotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Admin.UserNotFound);
     }
 
     [Fact]
@@ -530,7 +520,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Post($"/api/v1/admin/users/{userId}/verify-email", TestAuth.WithPermissions(AppPermissions.Users.Manage)));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Auth.EmailAlreadyVerified);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Auth.EmailAlreadyVerified);
     }
 
     #endregion
@@ -570,7 +560,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Post($"/api/v1/admin/users/{userId}/send-password-reset", TestAuth.WithPermissions(AppPermissions.Users.Manage)));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 404, ErrorMessages.Admin.UserNotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Admin.UserNotFound);
     }
 
     #endregion
@@ -616,7 +606,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
                 JsonContent.Create(new { Email = "existing@test.com" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Admin.EmailAlreadyRegistered);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Admin.EmailAlreadyRegistered);
     }
 
     #endregion
@@ -682,7 +672,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Get($"/api/v1/admin/roles/{roleId}", TestAuth.WithPermissions(AppPermissions.Roles.View)));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 404, ErrorMessages.Roles.RoleNotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Roles.RoleNotFound);
     }
 
     [Fact]
@@ -806,7 +796,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
                 JsonContent.Create(new { Permissions = new[] { "users.view" } })));
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 403, ErrorMessages.Roles.CannotGrantUnheldPermission);
+        await ProblemDetailsAssert.MatchesAsync(response, 403, ErrorMessages.Roles.CannotGrantUnheldPermission);
     }
 
     [Fact]
@@ -823,7 +813,7 @@ public class AdminControllerTests : IClassFixture<CustomWebApplicationFactory>, 
                 JsonContent.Create(new { Permissions = new[] { "users.view" } })));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 404, ErrorMessages.Roles.RoleNotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Roles.RoleNotFound);
     }
 
     [Fact]

--- a/src/backend/tests/MyProject.Api.Tests/Controllers/AuthControllerTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Controllers/AuthControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using MyProject.Api.Tests.Contracts;
 using MyProject.Api.Tests.Fixtures;
 using MyProject.Application.Cookies.Constants;
@@ -30,16 +29,6 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
         return msg;
     }
 
-    private static async Task AssertProblemDetailsAsync(
-        HttpResponseMessage response, int expectedStatus, string? expectedDetail = null)
-    {
-        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(expectedStatus, json.GetProperty("status").GetInt32());
-        if (expectedDetail is not null)
-        {
-            Assert.Equal(expectedDetail, json.GetProperty("detail").GetString());
-        }
-    }
 
     #region Login
 
@@ -75,7 +64,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/login", JsonContent.Create(new { Username = "test@example.com", Password = "wrong" })));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.LoginInvalidCredentials);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.LoginInvalidCredentials);
     }
 
     [Fact]
@@ -132,13 +121,13 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
         _factory.CaptchaService.ValidateTokenAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(true);
         _factory.AuthenticationService.Register(Arg.Any<RegisterInput>(), Arg.Any<CancellationToken>())
-            .Returns(Result<Guid>.Failure("Email already registered."));
+            .Returns(Result<Guid>.Failure(ErrorMessages.Admin.EmailAlreadyRegistered));
 
         var response = await _client.SendAsync(
             Post("/api/auth/register", JsonContent.Create(new { Email = "dup@example.com", Password = "Password1!", CaptchaToken = "valid-token" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, "Email already registered.");
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Admin.EmailAlreadyRegistered);
     }
 
     [Fact]
@@ -151,7 +140,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/register", JsonContent.Create(new { Email = "new@example.com", Password = "Password1!", CaptchaToken = "invalid-token" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Auth.CaptchaInvalid);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Auth.CaptchaInvalid);
     }
 
     [Fact]
@@ -208,7 +197,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/refresh", JsonContent.Create(new { })));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.TokenMissing);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.TokenMissing);
     }
 
     [Fact]
@@ -240,7 +229,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/refresh", JsonContent.Create(new { RefreshToken = "invalid" })));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.TokenInvalidated);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.TokenInvalidated);
     }
 
     [Fact]
@@ -279,7 +268,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
         var response = await _client.SendAsync(Post("/api/auth/logout"));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
     }
 
     #endregion
@@ -316,7 +305,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
     {
         _factory.AuthenticationService.ChangePasswordAsync(
                 Arg.Any<ChangePasswordInput>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Failure("Current password is incorrect."));
+            .Returns(Result.Failure(ErrorMessages.Auth.PasswordIncorrect));
 
         var response = await _client.SendAsync(
             Post("/api/auth/password/change",
@@ -324,7 +313,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
                 TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, "Current password is incorrect.");
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Auth.PasswordIncorrect);
     }
 
     #endregion
@@ -374,7 +363,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/password/forgot", JsonContent.Create(new { Email = "test@example.com", CaptchaToken = "invalid-token" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Auth.CaptchaInvalid);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Auth.CaptchaInvalid);
     }
 
     [Fact]
@@ -422,7 +411,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Auth.ResetPasswordTokenInvalid);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Auth.ResetPasswordTokenInvalid);
     }
 
     [Fact]
@@ -484,7 +473,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Auth.EmailVerificationFailed);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Auth.EmailVerificationFailed);
     }
 
     [Fact]
@@ -531,7 +520,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/email/resend-verification", auth: TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Auth.EmailAlreadyVerified);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Auth.EmailAlreadyVerified);
     }
 
     #endregion
@@ -593,7 +582,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/two-factor/login", JsonContent.Create(new { ChallengeToken = "challenge-token", Code = "000000" })));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.TwoFactor.InvalidCode);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.TwoFactor.InvalidCode);
     }
 
     [Fact]
@@ -647,7 +636,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/two-factor/login/recovery", JsonContent.Create(new { ChallengeToken = "challenge-token", RecoveryCode = "BAD-CODE" })));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.TwoFactor.RecoveryCodeInvalid);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.TwoFactor.RecoveryCodeInvalid);
     }
 
     [Fact]
@@ -687,7 +676,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
             Post("/api/auth/two-factor/setup"));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
     }
 
     #endregion
@@ -725,7 +714,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
                 TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.TwoFactor.VerificationFailed);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.TwoFactor.VerificationFailed);
     }
 
     [Fact]
@@ -736,7 +725,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
                 JsonContent.Create(new { Code = "123456" })));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
     }
 
     #endregion
@@ -765,7 +754,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
                 JsonContent.Create(new { Password = "Password1!" })));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
     }
 
     [Fact]
@@ -780,7 +769,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
                 TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.TwoFactor.NotEnabled);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.TwoFactor.NotEnabled);
     }
 
     #endregion
@@ -813,7 +802,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
                 JsonContent.Create(new { Password = "Password1!" })));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
     }
 
     [Fact]
@@ -828,7 +817,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>, I
                 TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.TwoFactor.NotEnabled);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.TwoFactor.NotEnabled);
     }
 
     #endregion

--- a/src/backend/tests/MyProject.Api.Tests/Controllers/ExternalAuthControllerTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Controllers/ExternalAuthControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using MyProject.Api.Tests.Contracts;
 using MyProject.Api.Tests.Fixtures;
 using MyProject.Application.Features.Authentication.Dtos;
@@ -36,16 +35,6 @@ public class ExternalAuthControllerTests : IClassFixture<CustomWebApplicationFac
         return msg;
     }
 
-    private static async Task AssertProblemDetailsAsync(
-        HttpResponseMessage response, int expectedStatus, string? expectedDetail = null)
-    {
-        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(expectedStatus, json.GetProperty("status").GetInt32());
-        if (expectedDetail is not null)
-        {
-            Assert.Equal(expectedDetail, json.GetProperty("detail").GetString());
-        }
-    }
 
     #region GetProviders
 
@@ -118,7 +107,7 @@ public class ExternalAuthControllerTests : IClassFixture<CustomWebApplicationFac
                 JsonContent.Create(new { Provider = "Unknown", RedirectUri = "https://example.com/oauth/callback" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.ExternalAuth.ProviderNotConfigured);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.ExternalAuth.ProviderNotConfigured);
     }
 
     [Fact]
@@ -223,7 +212,7 @@ public class ExternalAuthControllerTests : IClassFixture<CustomWebApplicationFac
                 JsonContent.Create(new { Code = "auth-code", State = "bad-state" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.ExternalAuth.InvalidState);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.ExternalAuth.InvalidState);
     }
 
     [Fact]
@@ -269,7 +258,7 @@ public class ExternalAuthControllerTests : IClassFixture<CustomWebApplicationFac
                 TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.ExternalAuth.CannotUnlinkLastMethod);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.ExternalAuth.CannotUnlinkLastMethod);
     }
 
     [Fact]
@@ -315,7 +304,7 @@ public class ExternalAuthControllerTests : IClassFixture<CustomWebApplicationFac
                 TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.ExternalAuth.PasswordAlreadySet);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.ExternalAuth.PasswordAlreadySet);
     }
 
     [Fact]

--- a/src/backend/tests/MyProject.Api.Tests/Controllers/OAuthProvidersControllerTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Controllers/OAuthProvidersControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using MyProject.Api.Tests.Contracts;
 using MyProject.Api.Tests.Fixtures;
 using MyProject.Application.Features.Authentication.Dtos;
@@ -44,16 +43,6 @@ public class OAuthProvidersControllerTests : IClassFixture<CustomWebApplicationF
         return request;
     }
 
-    private static async Task AssertProblemDetailsAsync(
-        HttpResponseMessage response, int expectedStatus, string? expectedDetail = null)
-    {
-        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(expectedStatus, json.GetProperty("status").GetInt32());
-        if (expectedDetail is not null)
-        {
-            Assert.Equal(expectedDetail, json.GetProperty("detail").GetString());
-        }
-    }
 
     #region ListProviders
 
@@ -140,7 +129,7 @@ public class OAuthProvidersControllerTests : IClassFixture<CustomWebApplicationF
                 JsonContent.Create(new { IsEnabled = true, ClientId = "id", ClientSecret = "secret" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, "The specified authentication provider is not recognized.");
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.ExternalAuth.UnknownProvider);
     }
 
     [Fact]
@@ -217,8 +206,7 @@ public class OAuthProvidersControllerTests : IClassFixture<CustomWebApplicationF
                 JsonContent.Create(new { IsEnabled = true, ClientId = "new-id" })));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400,
-            "A client secret is required when enabling a provider that has no existing secret.");
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.ExternalAuth.ClientSecretRequired);
     }
 
     [Fact]
@@ -264,7 +252,7 @@ public class OAuthProvidersControllerTests : IClassFixture<CustomWebApplicationF
                 TestAuth.WithPermissions(AppPermissions.OAuthProviders.Manage)));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400,
+        await ProblemDetailsAssert.MatchesAsync(response, 400,
             ErrorMessages.ExternalAuth.TestConnectionInvalidCredentials);
     }
 
@@ -280,7 +268,7 @@ public class OAuthProvidersControllerTests : IClassFixture<CustomWebApplicationF
                 TestAuth.WithPermissions(AppPermissions.OAuthProviders.Manage)));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400,
+        await ProblemDetailsAssert.MatchesAsync(response, 400,
             ErrorMessages.ExternalAuth.TestConnectionNotConfigured);
     }
 

--- a/src/backend/tests/MyProject.Api.Tests/Controllers/UsersControllerTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Controllers/UsersControllerTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Text.Json;
 using MyProject.Api.Tests.Contracts;
 using MyProject.Api.Tests.Fixtures;
 using MyProject.Application.Features.Audit.Dtos;
@@ -65,16 +64,6 @@ public class UsersControllerTests : IClassFixture<CustomWebApplicationFactory>, 
         return content;
     }
 
-    private static async Task AssertProblemDetailsAsync(
-        HttpResponseMessage response, int expectedStatus, string? expectedDetail = null)
-    {
-        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(expectedStatus, json.GetProperty("status").GetInt32());
-        if (expectedDetail is not null)
-        {
-            Assert.Equal(expectedDetail, json.GetProperty("detail").GetString());
-        }
-    }
 
     #region GetMe
 
@@ -103,7 +92,7 @@ public class UsersControllerTests : IClassFixture<CustomWebApplicationFactory>, 
         var response = await _client.SendAsync(Get("/api/users/me"));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
     }
 
     [Fact]
@@ -115,7 +104,7 @@ public class UsersControllerTests : IClassFixture<CustomWebApplicationFactory>, 
         var response = await _client.SendAsync(Get("/api/users/me", TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.User.NotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.User.NotFound);
     }
 
     #endregion
@@ -191,7 +180,7 @@ public class UsersControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Put("/api/users/me/avatar", CreateAvatarUpload(), TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.Avatar.FileTooLarge);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.Avatar.FileTooLarge);
     }
 
     #endregion
@@ -257,7 +246,7 @@ public class UsersControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Get($"/api/users/{userId}/avatar", TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 404, ErrorMessages.Avatar.NotFound);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Avatar.NotFound);
     }
 
     [Fact]
@@ -308,7 +297,7 @@ public class UsersControllerTests : IClassFixture<CustomWebApplicationFactory>, 
             Delete("/api/users/me", JsonContent.Create(new { Password = "WrongPass1!" }), TestAuth.User()));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        await AssertProblemDetailsAsync(response, 400, ErrorMessages.User.DeleteInvalidPassword);
+        await ProblemDetailsAssert.MatchesAsync(response, 400, ErrorMessages.User.DeleteInvalidPassword);
     }
 
     #endregion

--- a/src/backend/tests/MyProject.Api.Tests/Fixtures/ProblemDetailsAssert.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Fixtures/ProblemDetailsAssert.cs
@@ -1,0 +1,38 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using MyProject.Shared;
+
+namespace MyProject.Api.Tests.Fixtures;
+
+/// <summary>
+/// Shared assertions for <c>ProblemDetails</c> (RFC 9457) responses.
+/// </summary>
+public static class ProblemDetailsAssert
+{
+    /// <summary>
+    /// Asserts that the response body is a <c>ProblemDetails</c> with the expected status and, when
+    /// <paramref name="expectedError"/> is given, the expected <c>detail</c> and <c>code</c>.
+    /// </summary>
+    public static async Task MatchesAsync(HttpResponseMessage response, int expectedStatus, Error? expectedError = null)
+    {
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(expectedStatus, json.GetProperty("status").GetInt32());
+
+        if (expectedError is not null)
+        {
+            Assert.Equal(expectedError.Message, json.GetProperty("detail").GetString());
+            Assert.Equal(expectedError.Code, json.GetProperty("code").GetString());
+        }
+    }
+
+    /// <summary>
+    /// Asserts that the response body is a <c>ProblemDetails</c> with the expected status and <c>code</c>.
+    /// Use for framework-generated bodies (validation, status code pages) that have no <c>ErrorMessages</c> entry.
+    /// </summary>
+    public static async Task HasCodeAsync(HttpResponseMessage response, int expectedStatus, string expectedCode)
+    {
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(expectedStatus, json.GetProperty("status").GetInt32());
+        Assert.Equal(expectedCode, json.GetProperty("code").GetString());
+    }
+}

--- a/src/backend/tests/MyProject.Api.Tests/Middlewares/OriginValidationMiddlewareTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Middlewares/OriginValidationMiddlewareTests.cs
@@ -1,6 +1,4 @@
 using System.Net;
-using System.Net.Http.Json;
-using System.Text.Json;
 using MyProject.Api.Tests.Fixtures;
 using MyProject.Shared;
 
@@ -127,9 +125,7 @@ public class OriginValidationMiddlewareTests : IClassFixture<CustomWebApplicatio
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
 
-        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(403, json.GetProperty("status").GetInt32());
-        Assert.Equal(ErrorMessages.Security.CrossOriginRequestBlocked, json.GetProperty("detail").GetString());
+        await ProblemDetailsAssert.MatchesAsync(response, 403, ErrorMessages.Security.CrossOriginRequestBlocked);
     }
 
     // ── Origin case insensitivity ───────────────────────────────────

--- a/src/backend/tests/MyProject.Api.Tests/Middlewares/ProblemDetailsCodeTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Middlewares/ProblemDetailsCodeTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Json;
+using MyProject.Api.Tests.Fixtures;
+using MyProject.Application.Features.Authentication.Dtos;
+using MyProject.Shared;
+using MyProject.WebApi.Shared;
+using NSubstitute.ExceptionExtensions;
+
+namespace MyProject.Api.Tests.Middlewares;
+
+/// <summary>
+/// Verifies that every <c>ProblemDetails</c> response carries a machine-readable <c>code</c> extension,
+/// regardless of which part of the pipeline produced it (controller, authorization handler,
+/// exception middleware, model validation, status code pages).
+/// </summary>
+public class ProblemDetailsCodeTests : IClassFixture<CustomWebApplicationFactory>, IDisposable
+{
+    private readonly CustomWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public ProblemDetailsCodeTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _factory.ResetMocks();
+        _client = factory.CreateClient();
+    }
+
+    public void Dispose() => _client.Dispose();
+
+    [Fact]
+    public async Task ControllerFailure_IncludesErrorCode()
+    {
+        _factory.UserService.GetCurrentUserAsync(Arg.Any<CancellationToken>())
+            .Returns(Result<UserOutput>.Failure(ErrorMessages.User.NotFound, ErrorType.NotFound));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/users/me");
+        request.Headers.Add("Authorization", TestAuth.User());
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.User.NotFound);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_IncludesErrorCode()
+    {
+        var response = await _client.GetAsync("/api/users/me");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        await ProblemDetailsAssert.MatchesAsync(response, 401, ErrorMessages.Auth.NotAuthenticated);
+    }
+
+    [Fact]
+    public async Task Forbidden_IncludesErrorCode()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/admin/users?pageNumber=1&pageSize=10");
+        request.Headers.Add("Authorization", TestAuth.User());
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        await ProblemDetailsAssert.MatchesAsync(response, 403, ErrorMessages.Auth.InsufficientPermissions);
+    }
+
+    [Fact]
+    public async Task ModelValidationFailure_IncludesValidationFailedCode()
+    {
+        var response = await _client.PostAsync(
+            "/api/auth/login",
+            JsonContent.Create(new { Username = "", Password = "" }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await ProblemDetailsAssert.HasCodeAsync(response, 400, ProblemFactory.ValidationFailedCode);
+    }
+
+    [Fact]
+    public async Task UnmatchedRoute_IncludesFallbackCode()
+    {
+        var response = await _client.GetAsync("/api/does-not-exist");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await ProblemDetailsAssert.HasCodeAsync(response, 404, "not_found");
+    }
+
+    [Fact]
+    public async Task UnhandledException_IncludesErrorCode()
+    {
+        _factory.UserService.GetCurrentUserAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/users/me");
+        request.Headers.Add("Authorization", TestAuth.User());
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        await ProblemDetailsAssert.MatchesAsync(response, 500, ErrorMessages.Server.InternalError);
+    }
+
+    [Fact]
+    public async Task KeyNotFoundException_IncludesEntityNotFoundCode()
+    {
+        _factory.UserService.GetCurrentUserAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new KeyNotFoundException("missing"));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/users/me");
+        request.Headers.Add("Authorization", TestAuth.User());
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await ProblemDetailsAssert.MatchesAsync(response, 404, ErrorMessages.Entity.NotFound);
+    }
+}

--- a/src/backend/tests/MyProject.Api.Tests/Shared/ProblemFactoryTests.cs
+++ b/src/backend/tests/MyProject.Api.Tests/Shared/ProblemFactoryTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MyProject.Shared;
+using MyProject.WebApi.Shared;
+
+namespace MyProject.Api.Tests.Shared;
+
+public class ProblemFactoryTests
+{
+    private static readonly Error TestError = new("test_error", "Something went wrong.");
+
+    [Theory]
+    [InlineData(ErrorType.Validation, 400)]
+    [InlineData(ErrorType.Unauthorized, 401)]
+    [InlineData(ErrorType.Forbidden, 403)]
+    [InlineData(ErrorType.NotFound, 404)]
+    [InlineData(null, 400)]
+    public void Create_MapsErrorTypeToStatusAndCarriesDetailAndCode(ErrorType? errorType, int expectedStatus)
+    {
+        var result = ProblemFactory.Create(TestError, errorType);
+
+        var problem = Assert.IsType<ProblemDetails>(result.Value);
+        Assert.Equal(expectedStatus, result.StatusCode);
+        Assert.Equal(expectedStatus, problem.Status);
+        Assert.Equal(TestError.Message, problem.Detail);
+        Assert.Equal(TestError.Code, problem.Extensions[ProblemFactory.CodeExtensionKey]);
+    }
+
+    [Fact]
+    public void Create_WithNullError_OmitsDetailAndCode()
+    {
+        var result = ProblemFactory.Create(null, ErrorType.NotFound);
+
+        var problem = Assert.IsType<ProblemDetails>(result.Value);
+        Assert.Equal(404, problem.Status);
+        Assert.Null(problem.Detail);
+        Assert.False(problem.Extensions.ContainsKey(ProblemFactory.CodeExtensionKey));
+    }
+
+    [Fact]
+    public void CreateProblemDetails_CarriesStatusDetailAndCode()
+    {
+        var problem = ProblemFactory.CreateProblemDetails(TestError, StatusCodes.Status429TooManyRequests);
+
+        Assert.Equal(429, problem.Status);
+        Assert.Equal(TestError.Message, problem.Detail);
+        Assert.Equal(TestError.Code, problem.Extensions[ProblemFactory.CodeExtensionKey]);
+    }
+
+    [Fact]
+    public void EnsureCode_PreservesExistingCode()
+    {
+        var problem = ProblemFactory.CreateProblemDetails(TestError, StatusCodes.Status400BadRequest);
+
+        ProblemFactory.EnsureCode(problem);
+
+        Assert.Equal(TestError.Code, problem.Extensions[ProblemFactory.CodeExtensionKey]);
+    }
+
+    [Fact]
+    public void EnsureCode_ValidationProblem_UsesValidationFailedCode()
+    {
+        var problem = new HttpValidationProblemDetails { Status = StatusCodes.Status400BadRequest };
+
+        ProblemFactory.EnsureCode(problem);
+
+        Assert.Equal(ProblemFactory.ValidationFailedCode, problem.Extensions[ProblemFactory.CodeExtensionKey]);
+    }
+
+    [Theory]
+    [InlineData(400, "bad_request")]
+    [InlineData(404, "not_found")]
+    [InlineData(405, "method_not_allowed")]
+    [InlineData(415, "unsupported_media_type")]
+    [InlineData(500, "internal_server_error")]
+    public void EnsureCode_WithoutCode_FallsBackToSnakeCaseReasonPhrase(int status, string expectedCode)
+    {
+        var problem = new ProblemDetails { Status = status };
+
+        ProblemFactory.EnsureCode(problem);
+
+        Assert.Equal(expectedCode, problem.Extensions[ProblemFactory.CodeExtensionKey]);
+    }
+
+    [Fact]
+    public void EnsureCode_WithoutStatus_TreatsAsInternalServerError()
+    {
+        var problem = new ProblemDetails();
+
+        ProblemFactory.EnsureCode(problem);
+
+        Assert.Equal("internal_server_error", problem.Extensions[ProblemFactory.CodeExtensionKey]);
+    }
+}

--- a/src/backend/tests/MyProject.Component.Tests/Services/AuthenticationServiceTests.cs
+++ b/src/backend/tests/MyProject.Component.Tests/Services/AuthenticationServiceTests.cs
@@ -381,7 +381,8 @@ public class AuthenticationServiceTests : IDisposable
         var result = await _sut.Register(input);
 
         Assert.True(result.IsFailure);
-        Assert.Contains("Duplicate email", result.Error);
+        Assert.Equal(ErrorMessages.Auth.RegistrationInvalid.Code, result.Error?.Code);
+        Assert.Contains("Duplicate email", result.Error?.Message);
     }
 
     [Fact]
@@ -870,7 +871,8 @@ public class AuthenticationServiceTests : IDisposable
         var result = await _sut.ChangePasswordAsync(new ChangePasswordInput("current", "newPass1!"));
 
         Assert.True(result.IsFailure);
-        Assert.Contains("Password too common", result.Error);
+        Assert.Equal(ErrorMessages.Auth.PasswordPolicyViolation.Code, result.Error?.Code);
+        Assert.Contains("Password too common", result.Error?.Message);
     }
 
     #endregion
@@ -1159,7 +1161,8 @@ public class AuthenticationServiceTests : IDisposable
             new ResetPasswordInput(rawToken, "weak"));
 
         Assert.True(result.IsFailure);
-        Assert.Contains("Password too short", result.Error);
+        Assert.Equal(ErrorMessages.Auth.PasswordPolicyViolation.Code, result.Error?.Code);
+        Assert.Contains("Password too short", result.Error?.Message);
     }
 
     #endregion

--- a/src/backend/tests/MyProject.Component.Tests/Services/UserServiceTests.cs
+++ b/src/backend/tests/MyProject.Component.Tests/Services/UserServiceTests.cs
@@ -384,7 +384,7 @@ public class UserServiceTests : IDisposable
         var result = await _sut.UploadAvatarAsync([0xFF], "photo.exe", CancellationToken.None);
 
         Assert.True(result.IsFailure);
-        Assert.Contains("Unsupported", result.Error);
+        Assert.Equal(ErrorMessages.Avatar.UnsupportedFormat, result.Error);
         await _fileStorageService.DidNotReceive()
             .UploadAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -400,7 +400,7 @@ public class UserServiceTests : IDisposable
         _imageProcessingService.ProcessAvatar(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<int>())
             .Returns(Result<ProcessedImageOutput>.Success(processed));
         _fileStorageService.UploadAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Failure("S3 error"));
+            .Returns(Result.Failure(ErrorMessages.FileStorage.UploadFailed));
 
         var result = await _sut.UploadAvatarAsync([0xFF], "photo.jpg", CancellationToken.None);
 
@@ -499,7 +499,7 @@ public class UserServiceTests : IDisposable
         _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
         _userManager.GetRolesAsync(user).Returns(new List<string> { "User" });
         _fileStorageService.DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Failure("S3 error"));
+            .Returns(Result.Failure(ErrorMessages.FileStorage.DeleteFailed));
 
         var result = await _sut.RemoveAvatarAsync(CancellationToken.None);
 
@@ -570,7 +570,7 @@ public class UserServiceTests : IDisposable
         var user = new ApplicationUser { Id = _userId, UserName = "test@example.com", HasAvatar = true };
         _userManager.FindByIdAsync(_userId.ToString()).Returns(user);
         _fileStorageService.DownloadAsync($"avatars/{_userId}.webp", Arg.Any<CancellationToken>())
-            .Returns(Result<FileDownloadOutput>.Failure("Storage error"));
+            .Returns(Result<FileDownloadOutput>.Failure(ErrorMessages.FileStorage.DownloadFailed));
 
         var result = await _sut.GetAvatarAsync(_userId, CancellationToken.None);
 
@@ -610,7 +610,7 @@ public class UserServiceTests : IDisposable
         _userManager.GetRolesAsync(user).Returns(new List<string> { "User" });
         _userManager.DeleteAsync(user).Returns(IdentityResult.Success);
         _fileStorageService.DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Failure("S3 error"));
+            .Returns(Result.Failure(ErrorMessages.FileStorage.DeleteFailed));
 
         var result = await _sut.DeleteAccountAsync(new DeleteAccountInput("correct"));
 

--- a/src/backend/tests/MyProject.Unit.Tests/Shared/ErrorMessagesTests.cs
+++ b/src/backend/tests/MyProject.Unit.Tests/Shared/ErrorMessagesTests.cs
@@ -1,12 +1,41 @@
 using System.Reflection;
+using System.Text.RegularExpressions;
 using MyProject.Shared;
 
 namespace MyProject.Unit.Tests.Shared;
 
-public class ErrorMessagesTests
+public partial class ErrorMessagesTests
 {
     private static readonly string[] ExpectedNestedClasses =
         ["Auth", "User", "Admin", "Roles", "Pagination", "Server", "Jobs", "Security", "Entity"];
+
+    [GeneratedRegex("^[a-z][a-z0-9]*(_[a-z0-9]+)*$")]
+    private static partial Regex SnakeCaseRegex();
+
+    [GeneratedRegex("(?<!^)(?=[A-Z])")]
+    private static partial Regex PascalBoundaryRegex();
+
+    private static IEnumerable<(Type Type, FieldInfo Field, Error Error)> AllErrors()
+    {
+        var nestedTypes = typeof(ErrorMessages)
+            .GetNestedTypes(BindingFlags.Public | BindingFlags.Static);
+
+        foreach (var type in nestedTypes)
+        {
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(f => f.IsInitOnly && f.FieldType == typeof(Error));
+
+            foreach (var field in fields)
+            {
+                var error = (Error?)field.GetValue(null);
+                Assert.NotNull(error);
+                yield return (type, field, error);
+            }
+        }
+    }
+
+    private static string ToSnakeCase(string pascalCase) =>
+        PascalBoundaryRegex().Replace(pascalCase, "_").ToLowerInvariant();
 
     [Fact]
     public void AllNestedClasses_ShouldExist()
@@ -23,67 +52,84 @@ public class ErrorMessagesTests
     }
 
     [Fact]
-    public void AllConstStringFields_ShouldBeNonNullAndNonEmpty()
+    public void AllErrors_ShouldHaveNonEmptyMessage()
     {
-        var nestedTypes = typeof(ErrorMessages)
-            .GetNestedTypes(BindingFlags.Public | BindingFlags.Static);
-
-        foreach (var type in nestedTypes)
+        foreach (var (type, field, error) in AllErrors())
         {
-            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-                .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string));
-
-            foreach (var field in fields)
-            {
-                var value = (string?)field.GetRawConstantValue();
-                Assert.False(
-                    string.IsNullOrEmpty(value),
-                    $"ErrorMessages.{type.Name}.{field.Name} must not be null or empty.");
-            }
+            Assert.False(
+                string.IsNullOrWhiteSpace(error.Message),
+                $"ErrorMessages.{type.Name}.{field.Name} must have a non-empty message.");
         }
     }
 
     [Fact]
-    public void EachNestedClass_ShouldHaveAtLeastOneConstant()
+    public void EachNestedClass_ShouldHaveAtLeastOneError()
     {
         var nestedTypes = typeof(ErrorMessages)
             .GetNestedTypes(BindingFlags.Public | BindingFlags.Static);
 
         foreach (var type in nestedTypes)
         {
-            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-                .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(f => f.IsInitOnly && f.FieldType == typeof(Error))
                 .ToList();
 
             Assert.True(
                 fields.Count > 0,
-                $"ErrorMessages.{type.Name} should have at least one const string field.");
+                $"ErrorMessages.{type.Name} should have at least one Error field.");
         }
     }
 
     [Fact]
     public void ErrorMessages_WithinEachClass_ShouldBeUnique()
     {
-        var nestedTypes = typeof(ErrorMessages)
-            .GetNestedTypes(BindingFlags.Public | BindingFlags.Static);
+        var seen = new Dictionary<(Type Type, string Message), string>();
 
-        foreach (var type in nestedTypes)
+        foreach (var (type, field, error) in AllErrors())
         {
-            var seen = new Dictionary<string, string>();
-            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-                .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string));
+            var qualifiedName = $"ErrorMessages.{type.Name}.{field.Name}";
+            Assert.False(
+                seen.ContainsKey((type, error.Message)),
+                $"Duplicate error message \"{error.Message}\" found in {qualifiedName} and {seen.GetValueOrDefault((type, error.Message))}.");
+            seen[(type, error.Message)] = qualifiedName;
+        }
+    }
 
-            foreach (var field in fields)
-            {
-                var value = (string?)field.GetRawConstantValue();
-                if (value is null) continue;
+    [Fact]
+    public void ErrorCodes_ShouldBeSnakeCase()
+    {
+        foreach (var (type, field, error) in AllErrors())
+        {
+            Assert.True(
+                SnakeCaseRegex().IsMatch(error.Code),
+                $"ErrorMessages.{type.Name}.{field.Name} code \"{error.Code}\" must be snake_case.");
+        }
+    }
 
-                var qualifiedName = $"ErrorMessages.{type.Name}.{field.Name}";
-                Assert.False(
-                    seen.ContainsKey(value),
-                    $"Duplicate error message value \"{value}\" found in {qualifiedName} and {seen.GetValueOrDefault(value)}.");
-                seen[value] = qualifiedName;
-            }
+    [Fact]
+    public void ErrorCodes_ShouldBeDerivedFromDeclaringClassAndFieldName()
+    {
+        foreach (var (type, field, error) in AllErrors())
+        {
+            var expectedCode = $"{ToSnakeCase(type.Name)}_{ToSnakeCase(field.Name)}";
+            Assert.True(
+                expectedCode == error.Code,
+                $"ErrorMessages.{type.Name}.{field.Name} code must be \"{expectedCode}\" but was \"{error.Code}\".");
+        }
+    }
+
+    [Fact]
+    public void ErrorCodes_ShouldBeGloballyUnique()
+    {
+        var seen = new Dictionary<string, string>();
+
+        foreach (var (type, field, error) in AllErrors())
+        {
+            var qualifiedName = $"ErrorMessages.{type.Name}.{field.Name}";
+            Assert.False(
+                seen.ContainsKey(error.Code),
+                $"Duplicate error code \"{error.Code}\" found in {qualifiedName} and {seen.GetValueOrDefault(error.Code)}.");
+            seen[error.Code] = qualifiedName;
         }
     }
 }

--- a/src/backend/tests/MyProject.Unit.Tests/Shared/ResultGenericTests.cs
+++ b/src/backend/tests/MyProject.Unit.Tests/Shared/ResultGenericTests.cs
@@ -4,6 +4,8 @@ namespace MyProject.Unit.Tests.Shared;
 
 public class ResultGenericTests
 {
+    private static readonly Error TestError = new("test_error", "error");
+
     [Fact]
     public void Success_ShouldSetIsSuccessTrue()
     {
@@ -33,24 +35,29 @@ public class ResultGenericTests
     [Fact]
     public void Failure_ShouldSetIsSuccessFalse()
     {
-        var result = Result<int>.Failure("error");
+        var result = Result<int>.Failure(TestError);
 
         Assert.False(result.IsSuccess);
         Assert.True(result.IsFailure);
     }
 
     [Fact]
-    public void Failure_ShouldPreserveErrorMessage()
+    public void Failure_ShouldPreserveError()
     {
-        var result = Result<int>.Failure("something broke");
+        var error = new Error("something_broke", "something broke");
 
-        Assert.Equal("something broke", result.Error);
+        var result = Result<int>.Failure(error);
+
+        Assert.NotNull(result.Error);
+        Assert.Same(error, result.Error);
+        Assert.Equal("something_broke", result.Error.Code);
+        Assert.Equal("something broke", result.Error.Message);
     }
 
     [Fact]
-    public void Failure_WithMessage_ShouldDefaultToValidationErrorType()
+    public void Failure_WithError_ShouldDefaultToValidationErrorType()
     {
-        var result = Result<int>.Failure("error");
+        var result = Result<int>.Failure(TestError);
 
         Assert.Equal(ErrorType.Validation, result.ErrorType);
     }
@@ -59,9 +66,9 @@ public class ResultGenericTests
     [InlineData(ErrorType.Validation)]
     [InlineData(ErrorType.Unauthorized)]
     [InlineData(ErrorType.NotFound)]
-    public void Failure_WithMessageAndErrorType_ShouldPreserveErrorType(ErrorType errorType)
+    public void Failure_WithErrorAndErrorType_ShouldPreserveErrorType(ErrorType errorType)
     {
-        var result = Result<string>.Failure("error", errorType);
+        var result = Result<string>.Failure(TestError, errorType);
 
         Assert.Equal(errorType, result.ErrorType);
     }
@@ -69,7 +76,7 @@ public class ResultGenericTests
     [Fact]
     public void Value_OnFailure_ShouldThrowInvalidOperationException()
     {
-        var result = Result<int>.Failure("error");
+        var result = Result<int>.Failure(TestError);
 
         var exception = Assert.Throws<InvalidOperationException>(() => result.Value);
         Assert.Equal("Cannot access Value on a failed result.", exception.Message);
@@ -96,10 +103,10 @@ public class ResultGenericTests
     [Fact]
     public void ResultGeneric_Failure_InheritsFromResult()
     {
-        Result result = Result<int>.Failure("error", ErrorType.NotFound);
+        Result result = Result<int>.Failure(TestError, ErrorType.NotFound);
 
         Assert.True(result.IsFailure);
-        Assert.Equal("error", result.Error);
+        Assert.Equal(TestError, result.Error);
         Assert.Equal(ErrorType.NotFound, result.ErrorType);
     }
 }

--- a/src/backend/tests/MyProject.Unit.Tests/Shared/ResultTests.cs
+++ b/src/backend/tests/MyProject.Unit.Tests/Shared/ResultTests.cs
@@ -4,6 +4,8 @@ namespace MyProject.Unit.Tests.Shared;
 
 public class ResultTests
 {
+    private static readonly Error TestError = new("test_error", "something went wrong");
+
     [Fact]
     public void Success_ShouldSetIsSuccessTrue()
     {
@@ -30,26 +32,29 @@ public class ResultTests
     }
 
     [Fact]
-    public void Failure_WithMessage_ShouldSetIsSuccessFalse()
+    public void Failure_WithError_ShouldSetIsSuccessFalse()
     {
-        var result = Result.Failure("something went wrong");
+        var result = Result.Failure(TestError);
 
         Assert.False(result.IsSuccess);
         Assert.True(result.IsFailure);
     }
 
     [Fact]
-    public void Failure_WithMessage_ShouldPreserveError()
+    public void Failure_WithError_ShouldPreserveError()
     {
-        var result = Result.Failure("something went wrong");
+        var result = Result.Failure(TestError);
 
-        Assert.Equal("something went wrong", result.Error);
+        Assert.NotNull(result.Error);
+        Assert.Same(TestError, result.Error);
+        Assert.Equal("test_error", result.Error.Code);
+        Assert.Equal("something went wrong", result.Error.Message);
     }
 
     [Fact]
-    public void Failure_WithMessage_ShouldDefaultToValidationErrorType()
+    public void Failure_WithError_ShouldDefaultToValidationErrorType()
     {
-        var result = Result.Failure("something went wrong");
+        var result = Result.Failure(TestError);
 
         Assert.Equal(ErrorType.Validation, result.ErrorType);
     }
@@ -58,19 +63,21 @@ public class ResultTests
     [InlineData(ErrorType.Validation)]
     [InlineData(ErrorType.Unauthorized)]
     [InlineData(ErrorType.NotFound)]
-    public void Failure_WithMessageAndErrorType_ShouldPreserveErrorType(ErrorType errorType)
+    public void Failure_WithErrorAndErrorType_ShouldPreserveErrorType(ErrorType errorType)
     {
-        var result = Result.Failure("error", errorType);
+        var result = Result.Failure(TestError, errorType);
 
         Assert.Equal(errorType, result.ErrorType);
     }
 
     [Fact]
-    public void Failure_WithMessageAndErrorType_ShouldPreserveError()
+    public void Failure_WithErrorAndErrorType_ShouldPreserveError()
     {
-        var result = Result.Failure("not found", ErrorType.NotFound);
+        var error = new Error("not_found", "not found");
 
-        Assert.Equal("not found", result.Error);
+        var result = Result.Failure(error, ErrorType.NotFound);
+
+        Assert.Same(error, result.Error);
         Assert.False(result.IsSuccess);
     }
 }

--- a/src/frontend/src/lib/api/error-handling.test.ts
+++ b/src/frontend/src/lib/api/error-handling.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	getErrorCode,
 	getErrorMessage,
 	getRetryAfterSeconds,
 	isFetchErrorWithCode,
@@ -185,7 +186,67 @@ describe('mapFieldErrors', () => {
 	});
 });
 
+// ── getErrorCode ────────────────────────────────────────────────────
+
+describe('getErrorCode', () => {
+	it('ProblemDetails with code - returns code', () => {
+		const error = {
+			status: 409,
+			detail: 'Already linked.',
+			code: 'external_auth_already_linked_to_other_user'
+		};
+		expect(getErrorCode(error)).toBe('external_auth_already_linked_to_other_user');
+	});
+
+	it('ProblemDetails without code - returns null', () => {
+		expect(getErrorCode({ status: 404, detail: 'Not found.' })).toBeNull();
+	});
+
+	it('code is empty string - returns null', () => {
+		expect(getErrorCode({ code: '' })).toBeNull();
+	});
+
+	it('code is non-string - returns null', () => {
+		expect(getErrorCode({ code: 42 })).toBeNull();
+	});
+
+	it('null error - returns null', () => {
+		expect(getErrorCode(null)).toBeNull();
+	});
+
+	it('string error - returns null', () => {
+		expect(getErrorCode('oops')).toBeNull();
+	});
+});
+
 // ── getErrorMessage ─────────────────────────────────────────────────
+
+describe('getErrorMessage with messagesByCode', () => {
+	const messages = {
+		auth_login_account_locked: () => 'translated locked',
+		auth_login_invalid_credentials: () => 'translated invalid'
+	};
+
+	it('code matches a message - returns translated message over detail', () => {
+		const error = { detail: 'Account is temporarily locked.', code: 'auth_login_account_locked' };
+		expect(getErrorMessage(error, 'fallback', messages)).toBe('translated locked');
+	});
+
+	it('code without a matching message - falls back to detail', () => {
+		const error = { detail: 'Some other error.', code: 'unknown_code' };
+		expect(getErrorMessage(error, 'fallback', messages)).toBe('Some other error.');
+	});
+
+	it('no code - falls back to detail', () => {
+		const error = { detail: 'Detail only.' };
+		expect(getErrorMessage(error, 'fallback', messages)).toBe('Detail only.');
+	});
+
+	it('code without a matching message and no detail - returns fallback', () => {
+		const error = { code: 'unknown_code' };
+		expect(getErrorMessage(error, 'fallback', messages)).toBe('fallback');
+	});
+});
 
 describe('getErrorMessage', () => {
 	it('error with detail - returns detail', () => {

--- a/src/frontend/src/lib/api/error-handling.ts
+++ b/src/frontend/src/lib/api/error-handling.ts
@@ -9,19 +9,42 @@
  */
 
 /**
- * Extended ProblemDetails with validation errors.
- * ASP.NET Core returns field-level errors in an `errors` object.
+ * ProblemDetails (RFC 9457) as returned by the backend.
+ *
+ * Every error response carries a stable, machine-readable `code` (snake_case)
+ * alongside the human-readable `detail`. Branch on `code` - never on `detail` text.
  *
  * @see https://tools.ietf.org/html/rfc9457
  */
-export interface ValidationProblemDetails {
+export interface ProblemDetails {
 	type?: string | null;
 	title?: string | null;
 	status?: number | null;
 	detail?: string | null;
 	instance?: string | null;
+	code?: string | null;
+}
+
+/**
+ * Extended ProblemDetails with validation errors.
+ * ASP.NET Core returns field-level errors in an `errors` object.
+ */
+export interface ValidationProblemDetails extends ProblemDetails {
 	errors?: Record<string, string[]>;
 }
+
+/**
+ * Translated messages keyed by backend error `code`.
+ * Values are Paraglide message functions so translation happens lazily in the current locale.
+ *
+ * @example
+ * ```ts
+ * const messages: ErrorMessagesByCode = {
+ *   auth_login_account_locked: m.auth_login_accountLocked
+ * };
+ * ```
+ */
+export type ErrorMessagesByCode = Record<string, () => string>;
 
 /**
  * Type guard to check if an error response is a ValidationProblemDetails.
@@ -85,20 +108,51 @@ export function mapFieldErrors(
 }
 
 /**
+ * Extracts the machine-readable error `code` from a ProblemDetails API error response.
+ *
+ * @param error - The error object from the API response
+ * @returns The snake_case error code, or `null` when the response carries none
+ */
+export function getErrorCode(error: unknown): string | null {
+	if (
+		typeof error === 'object' &&
+		error !== null &&
+		'code' in error &&
+		typeof error.code === 'string' &&
+		error.code.length > 0
+	) {
+		return error.code;
+	}
+	return null;
+}
+
+/**
  * Extracts a user-friendly error message from a ProblemDetails API error response.
  *
  * Resolution order:
- * 1. `detail` field → ProblemDetails detail (the specific error message)
- * 2. `title` field → ProblemDetails title (generic status description)
- * 3. Fallback string
+ * 1. `code` field with a matching entry in `messagesByCode` -> translated message
+ * 2. `detail` field -> ProblemDetails detail (the specific English message)
+ * 3. `title` field -> ProblemDetails title (generic status description)
+ * 4. Fallback string
  *
- * The backend always returns specific, descriptive English messages in `detail`.
+ * Prefer passing `messagesByCode` for errors the UI wants to translate - the
+ * backend `code` is a stable contract, while `detail` text may change.
  *
  * @param error - The error object from the API response
  * @param fallback - Fallback message if no error message can be extracted
+ * @param messagesByCode - Optional translated messages keyed by backend error code
  * @returns A user-friendly error message
  */
-export function getErrorMessage(error: unknown, fallback: string): string {
+export function getErrorMessage(
+	error: unknown,
+	fallback: string,
+	messagesByCode?: ErrorMessagesByCode
+): string {
+	const code = getErrorCode(error);
+	const translated = code === null ? undefined : messagesByCode?.[code];
+	if (translated) {
+		return translated();
+	}
 	if (typeof error === 'object' && error !== null) {
 		if ('detail' in error && typeof error.detail === 'string') {
 			return error.detail;

--- a/src/frontend/src/lib/api/v1.d.ts
+++ b/src/frontend/src/lib/api/v1.d.ts
@@ -4007,6 +4007,8 @@ export interface components {
 			status?: null | number;
 			detail?: null | string;
 			instance?: null | string;
+			/** @description Stable, machine-readable error code (snake_case). Use it to branch on the error or as a translation key instead of matching the human-readable detail. */
+			code?: string;
 		};
 		/** @description Detailed recurring job response including execution history. */
 		RecurringJobDetailResponse: {

--- a/src/frontend/src/lib/components/auth/LoginForm.svelte
+++ b/src/frontend/src/lib/components/auth/LoginForm.svelte
@@ -69,14 +69,10 @@
 						fallback: m.auth_login_error(),
 						onRateLimited: () => shake.trigger(),
 						onError() {
-							const detail = getErrorMessage(apiError, '');
-							const isLocked = detail.includes('temporarily locked');
-							const errorMessage =
-								response.status === 401
-									? isLocked
-										? m.auth_login_accountLocked()
-										: getErrorMessage(apiError, m.auth_login_invalidCredentials())
-									: getErrorMessage(apiError, m.auth_login_error());
+							const errorMessage = getErrorMessage(apiError, m.auth_login_error(), {
+								auth_login_invalid_credentials: m.auth_login_invalidCredentials,
+								auth_login_account_locked: m.auth_login_accountLocked
+							});
 							toast.error(m.auth_login_failed(), { description: errorMessage });
 							shake.trigger();
 						}

--- a/src/frontend/src/messages/cs/oauth.json
+++ b/src/frontend/src/messages/cs/oauth.json
@@ -17,6 +17,8 @@
 	"oauth_callback_alreadyLinked": "Tento externí účet je již propojen s jiným uživatelem.",
 	"oauth_callback_emailNotVerified": "Před propojením externího účtu je nutné ověřit e-mailovou adresu. Nejprve prosím ověřte svůj e-mail.",
 	"oauth_callback_stateExpired": "Přihlašovací relace vypršela. Zkuste to prosím znovu.",
+	"oauth_callback_invalidState": "Přihlašovací požadavek je neplatný nebo již byl použit. Zkuste to prosím znovu.",
+	"oauth_callback_providerError": "Poskytovatel přihlášení vrátil chybu. Zkuste to prosím později.",
 	"oauth_callback_accountLocked": "Váš účet je dočasně uzamčen. Zkuste to prosím později.",
 
 	"settings_oauth_title": "Propojené účty",

--- a/src/frontend/src/messages/en/oauth.json
+++ b/src/frontend/src/messages/en/oauth.json
@@ -17,6 +17,8 @@
 	"oauth_callback_alreadyLinked": "This external account is already linked to another user.",
 	"oauth_callback_emailNotVerified": "Your email must be verified before linking an external account. Please verify your email first.",
 	"oauth_callback_stateExpired": "The sign-in session has expired. Please try again.",
+	"oauth_callback_invalidState": "The sign-in request is invalid or was already used. Please try again.",
+	"oauth_callback_providerError": "The sign-in provider returned an error. Please try again later.",
 	"oauth_callback_accountLocked": "Your account is temporarily locked. Please try again later.",
 
 	"settings_oauth_title": "Connected Accounts",

--- a/src/frontend/src/routes/(public)/oauth/callback/+page.server.ts
+++ b/src/frontend/src/routes/(public)/oauth/callback/+page.server.ts
@@ -1,4 +1,5 @@
 import { isRedirect, redirect } from '@sveltejs/kit';
+import { getErrorCode } from '$lib/api';
 import { routes } from '$lib/config';
 import type { PageServerLoad } from './$types';
 
@@ -24,9 +25,8 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 		});
 
 		if (!response.ok) {
-			const body = await response.json().catch(() => null);
-			const detail = body?.detail ?? 'Unknown error';
-			return { error: detail };
+			const body: unknown = await response.json().catch(() => null);
+			return { error: getErrorCode(body) ?? 'unknown_error' };
 		}
 
 		const data = await response.json();

--- a/src/frontend/src/routes/(public)/oauth/callback/+page.svelte
+++ b/src/frontend/src/routes/(public)/oauth/callback/+page.svelte
@@ -6,30 +6,28 @@
 	import { Loader2, CircleAlert } from '@lucide/svelte';
 	import { IconCircle } from '$lib/components/common';
 	import { AuthShell } from '$lib/components/auth';
+	import type { ErrorMessagesByCode } from '$lib/api';
 
 	let { data } = $props();
 
 	/**
-	 * Maps backend ProblemDetails `detail` strings to translated messages.
-	 * Keys are the exact English strings from ErrorMessages.cs.
-	 * Unmapped errors fall back to the generic description.
-	 *
-	 * TODO: Remove this map once the backend returns error codes instead of
-	 * English strings, and use those codes as i18n keys directly.
+	 * Translated messages keyed by error code. Backend codes come from the `code`
+	 * extension of the ProblemDetails response (see ErrorMessages.cs); the rest are
+	 * produced locally by the page load. Unmapped codes fall back to the generic description.
 	 */
-	const ERROR_MAP: Record<string, () => string> = {
-		provider_denied: () => m.oauth_callback_providerDenied(),
-		'This external account is already linked to another user.': () =>
-			m.oauth_callback_alreadyLinked(),
-		'Your email address must be verified before linking an external account. Please verify your email first.':
-			() => m.oauth_callback_emailNotVerified(),
-		'OAuth state token has expired. Please try again.': () => m.oauth_callback_stateExpired(),
-		'Account is temporarily locked. Please try again later or contact an administrator.': () =>
-			m.oauth_callback_accountLocked()
+	const ERROR_MESSAGES: ErrorMessagesByCode = {
+		provider_denied: m.oauth_callback_providerDenied,
+		external_auth_already_linked_to_other_user: m.oauth_callback_alreadyLinked,
+		external_auth_email_not_verified: m.oauth_callback_emailNotVerified,
+		external_auth_state_expired: m.oauth_callback_stateExpired,
+		external_auth_invalid_state: m.oauth_callback_invalidState,
+		external_auth_code_exchange_failed: m.oauth_callback_providerError,
+		external_auth_provider_error: m.oauth_callback_providerError,
+		auth_login_account_locked: m.oauth_callback_accountLocked
 	};
 
 	const errorMessage = $derived(
-		(data.error && ERROR_MAP[data.error]?.()) ?? m.oauth_callback_errorDescription()
+		(data.error && ERROR_MESSAGES[data.error]?.()) ?? m.oauth_callback_errorDescription()
 	);
 </script>
 

--- a/src/frontend/src/routes/(public)/oauth/callback/page.server.test.ts
+++ b/src/frontend/src/routes/(public)/oauth/callback/page.server.test.ts
@@ -111,27 +111,30 @@ describe('OAuth callback page server load', () => {
 
 	// ── API error responses ────────────────────────────────────
 
-	it('API returns error with detail - returns detail message', async () => {
+	it('API returns ProblemDetails with code - returns the code', async () => {
 		const result = await load(
 			mockLoadEvent({
 				searchParams: { code: 'auth-code', state: 'state-token' },
 				fetchResponse: {
 					ok: false,
-					json: { detail: 'Invalid or missing OAuth state token.' }
+					json: {
+						detail: 'Invalid or missing OAuth state token.',
+						code: 'external_auth_invalid_state'
+					}
 				}
 			})
 		);
-		expect(result).toEqual({ error: 'Invalid or missing OAuth state token.' });
+		expect(result).toEqual({ error: 'external_auth_invalid_state' });
 	});
 
-	it('API returns error without detail - returns Unknown error', async () => {
+	it('API returns error without code - returns unknown_error', async () => {
 		const result = await load(
 			mockLoadEvent({
 				searchParams: { code: 'auth-code', state: 'state-token' },
-				fetchResponse: { ok: false, json: {} }
+				fetchResponse: { ok: false, json: { detail: 'Some message.' } }
 			})
 		);
-		expect(result).toEqual({ error: 'Unknown error' });
+		expect(result).toEqual({ error: 'unknown_error' });
 	});
 
 	// ── Network error ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Introduce `Error(Code, Message)` in `MyProject.Shared`; every `ErrorMessages` entry is now an `Error` with a stable snake_case code (`{class}_{field}`, enforced by tests) and `Result`/`Result<T>` carry it
- Every `ProblemDetails` response includes a `code` extension next to the unchanged human `detail`: controllers via `ProblemFactory`, 401/403 authorization handler, exception middleware, origin validation, rate limiter, and framework-generated bodies (`validation_failed` for model validation, snake_case reason phrase such as `not_found` for status code pages) via `ProblemFactory.EnsureCode`
- `ProblemDetailsSchemaTransformer` documents `code` in OpenAPI; `v1.d.ts` regenerated from the real spec
- Frontend: `getErrorCode()` and an `ErrorMessagesByCode` option on `getErrorMessage()` translate by code; the OAuth callback page and `LoginForm` no longer match English `detail` strings (removes the last TODO and the `ERROR_MAP`); new `oauth_callback_invalidState`/`oauth_callback_providerError` messages in en and cs
- Docs: convention documented in `backend-conventions`/`frontend-conventions` skills, rules, FILEMAP and a session doc

Closes #452

## Breaking Changes
Response shape is additive for HTTP consumers: every `ProblemDetails` body gains a `code` string extension (for example `{"status":409,"detail":"This external account is already linked to another user.","code":"external_auth_already_linked_to_other_user"}`); `detail` text is unchanged. Two `detail` values that were previously ad-hoc are now centralized entries with identical text (S3 storage failures, `Too many requests...`), and Identity password/registration feedback keeps its dynamic text under the stable codes `auth_password_policy_violation` / `auth_registration_invalid`.

Source-level (C#): `Result.Error` is now `Error?` instead of `string?` and `Result.Failure(...)` takes an `Error`; `ErrorMessages.*` members are `Error` values (`.Message` gives the previous string). Callers of `ProblemFactory.Create` pass `result.Error` unchanged.

Error codes are a public contract from now on: adding a code is additive, renaming or removing one is breaking.

## Test Plan
- [x] Backend: `dotnet build src/backend/MyProject.slnx` (0 warnings) and `dotnet test src/backend/MyProject.slnx -c Release` (1082 tests green)
- [x] Frontend: `pnpm run test && pnpm run format && pnpm run lint && pnpm run check` (296 tests, only the 9 known `state_referenced_locally` warnings)
- [x] Fresh init: `./init.sh --name Test --port 14000 --yes --no-commit --no-aspire` on a copy builds, migrates and passes all tests; real responses from the initialized API carry `code` (`auth_not_authenticated` on 401, `not_found` on unmatched route, `validation_failed` on model validation)
- [ ] Reviewer: trigger an OAuth callback error (expired state) and confirm the localized message on `/oauth/callback`; wrong password on `/login` shows the translated invalid-credentials message

🤖 Generated with [Claude Code](https://claude.com/claude-code)